### PR TITLE
Not working under linux with double-backslashes

### DIFF
--- a/src/TypeGen/TypeGen.Cli/Business/ConfigProvider.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/ConfigProvider.cs
@@ -81,7 +81,7 @@ namespace TypeGen.Cli.Business
             }
 
             if (logVerbose) _logger.Log($"Reading assembly path from the config file: '{configAssemblyPath}'");
-            string assemblyPath = $"{projectFolder}\\{configAssemblyPath}";
+            string assemblyPath = $"{projectFolder}/{configAssemblyPath}";
 
             if (!_fileSystem.FileExists(assemblyPath))
             {
@@ -104,7 +104,7 @@ namespace TypeGen.Cli.Business
 
             string dllFileName = Path.ChangeExtension(projectFileName, "dll");
             string exeFileName = Path.ChangeExtension(projectFileName, "exe");
-            string binPath = $"{projectFolder}\\bin";
+            string binPath = $"{projectFolder}/bin";
 
             IEnumerable<string> foundFiles = _fileSystem.GetFilesRecursive(binPath, dllFileName)
                 .Concat(_fileSystem.GetFilesRecursive(binPath, exeFileName));

--- a/src/TypeGen/TypeGen.Cli/Business/ConfigProvider.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/ConfigProvider.cs
@@ -81,7 +81,7 @@ namespace TypeGen.Cli.Business
             }
 
             if (logVerbose) _logger.Log($"Reading assembly path from the config file: '{configAssemblyPath}'");
-            string assemblyPath = $"{projectFolder}/{configAssemblyPath}";
+            string assemblyPath = $"{projectFolder}{Path.DirectorySeparatorChar}{configAssemblyPath}";
 
             if (!_fileSystem.FileExists(assemblyPath))
             {
@@ -104,7 +104,7 @@ namespace TypeGen.Cli.Business
 
             string dllFileName = Path.ChangeExtension(projectFileName, "dll");
             string exeFileName = Path.ChangeExtension(projectFileName, "exe");
-            string binPath = $"{projectFolder}/bin";
+            string binPath = $"{projectFolder}{Path.DirectorySeparatorChar}bin";
 
             IEnumerable<string> foundFiles = _fileSystem.GetFilesRecursive(binPath, dllFileName)
                 .Concat(_fileSystem.GetFilesRecursive(binPath, exeFileName));


### PR DESCRIPTION
I'm using Docker to build these projects.
```
  Generating files for project "."...
EXEC : GENERIC error : Could not find a part of the path '/Project/.\bin'. [/Project/Project.csproj]
     at System.IO.UnixFileSystem.FileSystemEnumerable`1.OpenDirectory(String fullPath)
     at System.IO.UnixFileSystem.FileSystemEnumerable`1.Enumerate()
     at System.IO.UnixFileSystem.FileSystemEnumerable`1..ctor(String userPath, String searchPattern, SearchOption searchOption, SearchTarget searchTarget, Func`3 translateResult)
     at System.IO.UnixFileSystem.EnumeratePaths(String path, String searchPattern, SearchOption searchOption, SearchTarget searchTarget)
     at System.IO.Directory.InternalGetFileDirectoryNames(String path, String userPathOriginal, String searchPattern, Boolean includeFiles, Boolean includeDirs, SearchOption searchOption)
     at System.IO.Directory.GetFiles(String path, String searchPattern, SearchOption searchOption)
     at TypeGen.Cli.Business.ConfigProvider.GetDefaultAssemblyPath(String projectFolder)
     at TypeGen.Cli.Business.ConfigProvider.UpdateConfigAssemblyPaths(TgConfig config, String projectFolder, Boolean logVerbose)
     at TypeGen.Cli.Business.ConfigProvider.GetConfig(String configPath, String projectFolder, Boolean logVerbose)
     at TypeGen.Cli.Program.Generate(String projectFolder, String configPath, Boolean verbose)
     at TypeGen.Cli.Program.Main(String[] args)
/Project/Project.csproj(48,5): error MSB3073: The command "dotnet /root/.nuget/packages/typegen/1.5.9/tools/TypeGen.Cli.dll ." exited with code -1.
```