### PR TITLE
Update templates to fullfil jsdoc-format rules

### DIFF
--- a/src/TypeGen/TypeGen.Core/Templates/Class.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/Class.tpl
@@ -1,7 +1,7 @@
 /**
-* This is a TypeGen auto-generated file.
-* Any changes made to this file can be lost when this file is regenerated.
-*/
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
 
 $tg{imports}$tg{customHead}export class $tg{name}$tg{extends} {
 $tg{properties}$tg{customBody}

--- a/src/TypeGen/TypeGen.Core/Templates/Enum.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/Enum.tpl
@@ -1,7 +1,7 @@
 /**
-* This is a TypeGen auto-generated file.
-* Any changes made to this file can be lost when this file is regenerated.
-*/
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
 
 export$tg{modifiers} enum $tg{name} {
 $tg{values}

--- a/src/TypeGen/TypeGen.Core/Templates/Interface.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/Interface.tpl
@@ -1,7 +1,7 @@
 /**
-* This is a TypeGen auto-generated file.
-* Any changes made to this file can be lost when this file is regenerated.
-*/
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
 
 $tg{imports}$tg{customHead}export interface $tg{name}$tg{extends} {
 $tg{properties}$tg{customBody}


### PR DESCRIPTION
When using TSLint, it by default complains about the code generated from TypeGen since the comments on the start don't comply with the [jsdoc-format rule](https://palantir.github.io/tslint/rules/jsdoc-format/). Simply aligning the asteriks in the comments solve that.