### PR TITLE
Cli: Check if `outputPath` has been set

### DIFF
--- a/src/TypeGen/TypeGen.Cli/Program.cs
+++ b/src/TypeGen/TypeGen.Cli/Program.cs
@@ -67,8 +67,10 @@ namespace TypeGen.Cli
                     _assemblyResolver = new AssemblyResolver(_fileSystem, projectFolder);
 
                     _logger.Log($"Generating files for project \"{projectFolder}\"...");
-                    Generate(projectFolder, configPath, verbose);
-                    _logger.Log($"Files for project \"{projectFolder}\" generated successfully.", "");
+                    if (Generate(projectFolder, configPath, verbose))
+                    {
+                        _logger.Log($"Files for project \"{projectFolder}\" generated successfully.", "");
+                    }
                 }
             }
             catch (Exception e) when (e is CliException || e is CoreException)
@@ -98,7 +100,7 @@ namespace TypeGen.Cli
             }
         }
 
-        private static void Generate(string projectFolder, string configPath, bool verbose)
+        private static bool Generate(string projectFolder, string configPath, bool verbose)
         {
             // get config
 
@@ -107,6 +109,12 @@ namespace TypeGen.Cli
                 : Path.Combine(projectFolder, "tgconfig.json");
 
             TgConfig config = _configProvider.GetConfig(configPath, projectFolder, verbose);
+
+            if (config.OutputPath == null)
+            {
+                _logger.Log("ERROR: Your config doesn't contain an outputPath.");
+                return false;
+            }
 
             // register assembly resolver
 
@@ -136,6 +144,8 @@ namespace TypeGen.Cli
             // unregister assembly resolver
 
             _assemblyResolver.Unregister();
+
+            return true;
         }
 
         private static void AddFilesToProject(string projectFolder, IEnumerable<string> generatedFiles)


### PR DESCRIPTION
If one forgets to set the `outputPath` property, TypeGen fails with a generic error:
```
Generating files for project "."...
GENERIC ERROR: Value cannot be null.
Parameter name: path2
   at System.IO.Path.Combine(String path1, String path2)
   at TypeGen.Cli.Program.Generate(String projectFolder, String configPath, Boolean verbose)
   at TypeGen.Cli.Program.Main(String[] args)
```

This PR would change it to be more descriptive:
```
Generating files for project "."...
ERROR: Your config doesn't contain an outputPath.
```