### PR TITLE
Add option for generating index file

### DIFF
--- a/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
+++ b/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
@@ -57,6 +57,9 @@ namespace TypeGen.Cli.Models
         [DataMember(Name = "outputPath")]
         public string OutputPath { get; set; }
 
+        [DataMember(Name = "createIndexFile")]
+        public bool? CreateIndexFile { get; set; }
+
         [DataMember(Name = "strictNullChecks")]
         public bool? StrictNullChecks { get; set; }
 
@@ -88,6 +91,7 @@ namespace TypeGen.Cli.Models
             if (PropertyNameConverters == null) PropertyNameConverters = GeneratorOptions.DefaultPropertyNameConverters.GetTypeNames().ToArray();
             if (EnumValueNameConverters == null) EnumValueNameConverters = GeneratorOptions.DefaultEnumValueNameConverters.GetTypeNames().ToArray();
             if (ExternalAssemblyPaths == null) ExternalAssemblyPaths = new string[0];
+            if (CreateIndexFile == null) CreateIndexFile = GeneratorOptions.DefaultCreateIndexFile;
             if (StrictNullChecks == null) StrictNullChecks = GeneratorOptions.DefaultStrictNullChecks;
             if (CsNullableTranslation == null) CsNullableTranslation = GeneratorOptions.DefaultCsNullableTranslation.ToFlagString();
             if (OutputPath == null) OutputPath = "";

--- a/src/TypeGen/TypeGen.Cli/Program.cs
+++ b/src/TypeGen/TypeGen.Cli/Program.cs
@@ -135,15 +135,17 @@ namespace TypeGen.Cli
 
             if (config.CreateIndexFile ?? GeneratorOptions.DefaultCreateIndexFile)
             {
-                using (var indexFile = new StreamWriter(Path.Combine(generatorOptions.BaseOutputDirectory, "index.ts")))
+                string typeScriptFileExtension = "";
+                if (!string.IsNullOrEmpty(generatorOptions.TypeScriptFileExtension))
+                {
+                    typeScriptFileExtension = "." + generatorOptions.TypeScriptFileExtension;
+                }
+                string indexFileName = Path.Combine(generatorOptions.BaseOutputDirectory, "index" + typeScriptFileExtension);
+                using (var indexFile = new StreamWriter(indexFileName))
                 {
                     foreach (string file in generatedFiles)
                     {
-                        string fileNameWithoutExt = file.Replace("\\", "/");
-                        if (!string.IsNullOrEmpty(generatorOptions.TypeScriptFileExtension))
-                        {
-                            fileNameWithoutExt = fileNameWithoutExt.Remove(fileNameWithoutExt.Length - 1 - generatorOptions.TypeScriptFileExtension.Length);
-                        }
+                        string fileNameWithoutExt = file.Remove(file.Length - typeScriptFileExtension.Length).Replace("\\", "/");
                         indexFile.WriteLine($"export * from './{fileNameWithoutExt}';");
                     }
                 }

--- a/src/TypeGen/TypeGen.Cli/Program.cs
+++ b/src/TypeGen/TypeGen.Cli/Program.cs
@@ -133,6 +133,22 @@ namespace TypeGen.Cli
                 AddFilesToProject(projectFolder, generatedFiles);
             }
 
+            if (config.CreateIndexFile ?? GeneratorOptions.DefaultCreateIndexFile)
+            {
+                using (var indexFile = new StreamWriter(Path.Combine(generatorOptions.BaseOutputDirectory, "index.ts")))
+                {
+                    foreach (string file in generatedFiles)
+                    {
+                        string fileNameWithoutExt = file.Replace("\\", "/");
+                        if (!string.IsNullOrEmpty(generatorOptions.TypeScriptFileExtension))
+                        {
+                            fileNameWithoutExt = fileNameWithoutExt.Remove(fileNameWithoutExt.Length - 1 - generatorOptions.TypeScriptFileExtension.Length);
+                        }
+                        indexFile.WriteLine($"export * from './{fileNameWithoutExt}';");
+                    }
+                }
+            }
+
             // unregister assembly resolver
 
             _assemblyResolver.Unregister();

--- a/src/TypeGen/TypeGen.Cli/Program.cs
+++ b/src/TypeGen/TypeGen.Cli/Program.cs
@@ -26,7 +26,6 @@ namespace TypeGen.Cli
         private static readonly ConfigProvider _configProvider;
         private static readonly GeneratorOptionsProvider _generatorOptionsProvider;
         private static readonly ProjectFileManager _projectFileManager;
-        private static readonly TemplateService _templateService;
         private static AssemblyResolver _assemblyResolver;
 
         static Program()
@@ -152,6 +151,7 @@ namespace TypeGen.Cli
                 string content = templateService.FillIndexTemplate(exports);
 
                 string indexFileName = Path.Combine(generatorOptions.BaseOutputDirectory, "index" + typeScriptFileExtension);
+                    // better: use templateservice and filesystem from generator class
                 using (var indexFile = new StreamWriter(indexFileName))
                 {
                     indexFile.Write(content);

--- a/src/TypeGen/TypeGen.Core/Business/TemplateService.cs
+++ b/src/TypeGen/TypeGen.Core/Business/TemplateService.cs
@@ -20,6 +20,8 @@ namespace TypeGen.Core.Business
         private string _interfaceTemplate;
         private string _interfacePropertyTemplate;
         private string _importTemplate;
+        private string _indexTemplate;
+        private string _indexExportTemplate;
 
         public GeneratorOptions GeneratorOptions { get; set; }
 
@@ -39,6 +41,8 @@ namespace TypeGen.Core.Business
             _interfaceTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.Interface.tpl");
             _interfacePropertyTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.InterfaceProperty.tpl");
             _importTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.Import.tpl");
+            _indexTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.Index.tpl");
+            _indexExportTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.IndexExport.tpl");
         }
 
         public string FillClassTemplate(string imports, string name, string extends, string properties, string customHead, string customBody)
@@ -110,6 +114,18 @@ namespace TypeGen.Core.Business
                 .Replace(GetTag("name"), name)
                 .Replace(GetTag("asAlias"), asAlias)
                 .Replace(GetTag("path"), path);
+        }
+
+        public string FillIndexTemplate(string exports)
+        {
+            return ReplaceSpecialChars(_indexTemplate)
+                .Replace(GetTag("exports"), exports);
+        }
+
+        public string FillIndexExportTemplate(string filename)
+        {
+            return ReplaceSpecialChars(_indexExportTemplate)
+                .Replace(GetTag("filename"), filename);
         }
 
         public string GetExtendsText(string name) => $" extends {name}";

--- a/src/TypeGen/TypeGen.Core/GeneratorOptions.cs
+++ b/src/TypeGen/TypeGen.Core/GeneratorOptions.cs
@@ -20,6 +20,7 @@ namespace TypeGen.Core
         public static NameConverterCollection DefaultEnumValueNameConverters => new NameConverterCollection();
         public static string DefaultTypeScriptFileExtension => "ts";
         public static bool DefaultSingleQuotes => false;
+        public static bool DefaultCreateIndexFile => false;
         public static bool DefaultStrictNullChecks => false;
         public static StrictNullFlags DefaultCsNullableTranslation => StrictNullFlags.Regular;
 

--- a/src/TypeGen/TypeGen.Core/Templates/Index.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/Index.tpl
@@ -1,0 +1,6 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+$tg{exports}

--- a/src/TypeGen/TypeGen.Core/Templates/IndexExport.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/IndexExport.tpl
@@ -1,0 +1,1 @@
+export * from './$tg{filename}';

--- a/src/TypeGen/TypeGen.Core/TypeGen.Core.csproj
+++ b/src/TypeGen/TypeGen.Core/TypeGen.Core.csproj
@@ -12,6 +12,8 @@
     <None Remove="Templates\Import.tpl" />
     <None Remove="Templates\Interface.tpl" />
     <None Remove="Templates\InterfaceProperty.tpl" />
+    <None Remove="Templates\Index.tpl" />
+    <None Remove="Templates\IndexExport.tpl" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Templates\Class.tpl" />
@@ -22,6 +24,8 @@
     <EmbeddedResource Include="Templates\Import.tpl" />
     <EmbeddedResource Include="Templates\Interface.tpl" />
     <EmbeddedResource Include="Templates\InterfaceProperty.tpl" />
+    <EmbeddedResource Include="Templates\Index.tpl" />
+    <EmbeddedResource Include="Templates\IndexExport.tpl" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />


### PR DESCRIPTION
This PR would add the option `CreateIndexFile`, with which TypeGen would also generate an `index.ts` which reexports all generated types, such that one can write for example:

```
import { A, B, C } from './api';
```

instead of:

```
import { A } from './api/a';
import { B } from './api/b';
import { C } from './api/c';
```

I just wonder: Would it be better to access `_fileSystem` and `_templateService` from the `Generator` instead of creating my own instances (which on the other hand would mean having to add them to the `IGenerator` interface)?