### PR TITLE
Cross platform fixes

### DIFF
--- a/src/TypeGen/TypeGen.Core.Test/Utils/FileSystemUtilsTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/Utils/FileSystemUtilsTest.cs
@@ -16,7 +16,7 @@ namespace TypeGen.Core.Test.Utils
         [InlineData(@"some\test/path")]
         public void SplitPathSeparator_PathGiven_PathSplit(string path)
         {
-            string[] splitPath = FileSystemUtils.SplitPathSeperator(path);
+            string[] splitPath = FileSystemUtils.SplitPathSeparator(path);
             Assert.Equal(new[] { "some", "test", "path" }, splitPath);
         }
 

--- a/src/TypeGen/TypeGen.Core.Test/Utils/FileSystemUtilsTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/Utils/FileSystemUtilsTest.cs
@@ -31,8 +31,8 @@ namespace TypeGen.Core.Test.Utils
         }
 
         [Theory]
-        [InlineData(@"my\project\folder", @"my\project\folder\jkl.csproj")]
-        [InlineData("my/project/folder", @"my/project/folder\jkl.csproj")]
+        [InlineData(@"my\project\folder", @"my/project/folder/jkl.csproj")]
+        [InlineData("my/project/folder", @"my/project/folder/jkl.csproj")]
         public void GetProjectFilePath_PathGiven_GetsProjectFile(string projectFolder, string expectedResult)
         {
             //arrange

--- a/src/TypeGen/TypeGen.Core/Generator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator.cs
@@ -341,13 +341,7 @@ namespace TypeGen.Core
             propertiesText += memberInfos
                 .Aggregate(propertiesText, (current, memberInfo) => current + GetClassPropertyText(memberInfo));
 
-            if (propertiesText != "")
-            {
-                // remove the last new line symbol
-                propertiesText = propertiesText.Remove(propertiesText.Length - 2);
-            }
-
-            return propertiesText;
+            return RemoveLastLineEnding(propertiesText);
         }
 
         /// <summary>
@@ -381,13 +375,7 @@ namespace TypeGen.Core
             propertiesText += memberInfos
                 .Aggregate(propertiesText, (current, memberInfo) => current + GetInterfacePropertyText(memberInfo));
 
-            if (propertiesText != "")
-            {
-                // remove the last new line symbol
-                propertiesText = propertiesText.Remove(propertiesText.Length - 2);
-            }
-
-            return propertiesText;
+            return RemoveLastLineEnding(propertiesText);
         }
 
         /// <summary>
@@ -415,13 +403,7 @@ namespace TypeGen.Core
             valuesText += enumValues.Cast<object>()
                 .Aggregate(valuesText, (current, enumValue) => current + GetEnumValueText(enumValue));
 
-            if (valuesText != "")
-            {
-                // remove the last new line symbol
-                valuesText = valuesText.Remove(valuesText.Length - 2);
-            }
-
-            return valuesText;
+            return RemoveLastLineEnding(valuesText);
         }
 
         /// <summary>
@@ -528,6 +510,11 @@ namespace TypeGen.Core
 
                 throw;
             }
+        }
+
+        private static string RemoveLastLineEnding(string propertiesText)
+        {
+            return propertiesText.TrimEnd('\r', '\n');
         }
     }
 }

--- a/src/TypeGen/TypeGen.Core/Storage/InternalStorage.cs
+++ b/src/TypeGen/TypeGen.Core/Storage/InternalStorage.cs
@@ -24,10 +24,10 @@ namespace TypeGen.Core.Storage
                 {
                     throw new CoreException($"Could not find embedded resource '{name}'");
                 }
-
+                
                 var contentBytes = new byte[stream.Length];
                 stream.Read(contentBytes, 0, (int)stream.Length);
-                return Encoding.ASCII.GetString(contentBytes);
+                return Encoding.UTF8.GetString(contentBytes);
             }
         }
     }

--- a/src/TypeGen/TypeGen.Core/TypeGen.Core.csproj
+++ b/src/TypeGen/TypeGen.Core/TypeGen.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.3</TargetFrameworks>
-    <DocumentationFile>\TypeGen.Core.xml</DocumentationFile>
+    <DocumentationFile>TypeGen.Core.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Templates\Class.tpl" />

--- a/src/TypeGen/TypeGen.Core/Utils/FileSystemUtils.cs
+++ b/src/TypeGen/TypeGen.Core/Utils/FileSystemUtils.cs
@@ -11,14 +11,14 @@ namespace TypeGen.Core.Utils
     /// <summary>
     /// File system-related utility class
     /// </summary>
-    internal class FileSystemUtils
+    internal static class FileSystemUtils
     {
         /// <summary>
-        /// Split paths by seperator with \\ and /
+        /// Split paths by separator with \\ and /
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
-        public static string[] SplitPathSeperator(string path)
+        public static string[] SplitPathSeparator(string path)
         {
             Requires.NotNullOrEmpty(path, nameof(path));
             return path.Split('\\', '/');
@@ -27,7 +27,7 @@ namespace TypeGen.Core.Utils
         public static string GetFileNameFromPath(string path)
         {
             Requires.NotNullOrEmpty(path, nameof(path));
-            return SplitPathSeperator(path).Last();
+            return SplitPathSeparator(path).Last();
         }
 
         public static string GetProjectFilePath(IFileSystem fileSystem, string projectFolder)
@@ -39,7 +39,7 @@ namespace TypeGen.Core.Utils
                 .Select(GetFileNameFromPath)
                 .FirstOrDefault(n => n.EndsWith(".csproj"));
 
-            return fileName == null ? null : Path.Combine(projectFolder, fileName);
+            return fileName == null ? null : Path.Combine(projectFolder, fileName).Replace('\\', '/');
         }
 
         /// <summary>

--- a/src/TypeGen/TypeGen.Core/Utils/FileSystemUtils.cs
+++ b/src/TypeGen/TypeGen.Core/Utils/FileSystemUtils.cs
@@ -34,7 +34,7 @@ namespace TypeGen.Core.Utils
         {
             Requires.NotNull(fileSystem, nameof(fileSystem));
             Requires.NotNullOrEmpty(projectFolder, nameof(projectFolder));
-            
+            projectFolder = projectFolder.Replace('\\', '/');
             string fileName = fileSystem.GetDirectoryFiles(projectFolder)
                 .Select(GetFileNameFromPath)
                 .FirstOrDefault(n => n.EndsWith(".csproj"));
@@ -51,8 +51,8 @@ namespace TypeGen.Core.Utils
         /// <returns></returns>
         public static string GetPathDiff(string pathFrom, string pathTo)
         {
-            var pathFromUri = new Uri("file:///" + pathFrom);
-            var pathToUri = new Uri("file:///" + pathTo);
+            var pathFromUri = new Uri("file:///" + pathFrom?.Replace('\\', '/'));
+            var pathToUri = new Uri("file:///" + pathTo?.Replace('\\', '/'));
 
             return pathFromUri.MakeRelativeUri(pathToUri).ToString();
         }


### PR DESCRIPTION
* Both forward and backward slashes are valid path separators on Windows but only forward slash is valid on Linux and MacOS. I'm trying to fix this one by using just forward slashes.
* Line endings on Windows are "\n\r" while on mac are just "\n". Removing two chars from the end of line would also remove the last semicolon in a generated interface.