### PR TITLE
Fix (slowly) trying to resolve missing assemblies over and over again

### DIFF
--- a/src/TypeGen/TypeGen.Cli/Business/AssemblyResolver.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/AssemblyResolver.cs
@@ -91,11 +91,9 @@ namespace TypeGen.Cli.Business
 
             // nuget
             assembly = FindRecursive(_nugetPackagesFolders, assemblyFileName, assemblyVersion);
-            if (assembly != null) return assembly;
-
-            // exception if assembly not found
-
-            throw new AssemblyResolutionException($"Could not resolve assembly: {args.Name} in any of the searched directories: {string.Join("; ", Directories)}");
+            
+            // return assembly or null
+            return assembly;
         }
 
         private Assembly FindByPackageName(IEnumerable<string> directories, string assemblyFullName)


### PR DESCRIPTION
Throwing an exception from `AssemblyResolve` causes the runtime to retry resolving the assembly (only to fail again) on the next occasion.
Given enough assemblies to resolve, several installed versions of the dotnet sdk and a lot of packages in the nuget cache, TypeGen would take minutes to complete/fail when assemblies are missing.

Returning null from `AssemblyResolve` when the assembly is not found (like described in https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.assemblyresolve?view=netframework-4.7.2#remarks) leads to the expected behaviour (each assembly being resolved once).