### PR TITLE
CustomTypeMappings improvements (...)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 platform: Any CPU
 configuration: Release

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
@@ -61,17 +61,14 @@ namespace TypeGen.Core.Generator.Services
                     customType = GenerateCustomType(t, customTypeMappingValue);
                     return true;
                 }
-                else
+                else if (t.IsConstructedGenericType)
                 {
-                    // Type can be a constructed generic or the generic itself
-                    if (t.IsConstructedGenericType || t.GenericTypeArguments.Length > 0)
+                    // Check for generic type
+                    Type genericType = t.GetGenericTypeDefinition();
+                    if (GeneratorOptions.CustomTypeMappings.TryGetValue(genericType.FullName, out customTypeMappingValue))
                     {
-                        Type genericType = t.IsConstructedGenericType ? t.GetGenericTypeDefinition() : t;
-                        if (GeneratorOptions.CustomTypeMappings.TryGetValue(genericType.FullName, out customTypeMappingValue))
-                        {
-                            customType = GenerateCustomType(t, customTypeMappingValue);
-                            return true;
-                        }
+                        customType = GenerateCustomType(t, customTypeMappingValue);
+                        return true;
                     }
                 }
             }

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
@@ -242,7 +242,8 @@ namespace TypeGen.Core.Generator.Services
                     throw new CoreException($"No type specified in TsType attribute for member '{memberInfo.Name}' declared in '{memberInfo.DeclaringType?.FullName}'");
                 }
 
-                return typeAttribute.TypeName;
+                Type type = GetMemberType(memberInfo);
+                return GenerateCustomType(type, typeAttribute.TypeName);
             }
 
             return GetTsTypeNameForMember(memberInfo);


### PR DESCRIPTION
This PR adds all-around improvements for `CustomTypeMappings` support, providing a way to fix #89 in the process. In detail:

## Unit tests

I didn't find unit tests for `CustomTypeMappings`. This is now the case with `GetTsTypeName_CustomTypeGiven_CustomTsTypeNameReturned`.

It's similar to `GetTsTypeName_MemberGiven_TsTypeNameReturned`, except it adds a `customType` and an `expectedCustomTypeName`

## `CustomTypeMappings` now apply to all objects

The mapping of custom types has been pulled from `GetTsSimpleTypeName(Type)` to its caller, `GetTsTypeName(Type, bool)`. This allows `CustomTypeMappings` to also apply to collections, dictionaries, and user generic types.

The signature of `bool TryGetCustomMapping(Type, out string)` follows the signature from [IDictionary<TKey,TValue>.TryGetValue(TKey, out TValue)](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.idictionary-2.trygetvalue?view=netframework-4.8).

## `CustomTypeMappings` and `TsTypeAttribute` now support generic custom type names by specifying `<>`

Adding `<>` to the value of a `CustomTypeMapping` will now cause a generic type name to be output with the same type arguments as the type in the key.

Taking the example from #89 (which I have edited to fix):

```
    CustomTypeMappings.Add(typeof(Dictionary<,>).FullName, "Map")
will generate:
    myDictionary: Map;

whereas:

    CustomTypeMappings.Add(typeof(Dictionary<,>).FullName, "Map<>")
will generate:
    myDictionary: Map<string,MyClass2>;

```

This also applies on a per-property or per-field basis with `TsTypeAttribute` and the relevant `Type(typeName)` method on the GeneratorSpec builder.

No change is made to type imports in the generated TS file : the custom type name is assumed to be either a known global type (like `Map` or `Set`), or somehow present during Typescript compilation.

The documentation of [Custom type mappings](https://typegen.readthedocs.io/en/latest/otherfeatures.html#custom-type-mappings) and  [TsTypeAttribute](https://typegen.readthedocs.io/en/latest/attributes.html#tstypeattribute) will probably need to be updated with this tidbit.

## Misc: Appveyor update

appveyor.yml has been updated to use the VS2019 build image, supporting the .NET Core 3 SDK, which basically fixes [this](https://ci.appveyor.com/project/JacekBurzynski/typegen/builds/29705067).
