### PR TITLE
Adding support for Interfaces implements and Interfaces extensions

### DIFF
--- a/src/TypeGen/TypeGen.Core.Test/Business/TsContentGeneratorTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/Business/TsContentGeneratorTest.cs
@@ -226,7 +226,29 @@ namespace TypeGen.Core.Test.Business
             //act,assert
             Assert.Throws<ArgumentNullException>(() => tsContentGenerator.GetExtendsText(typeof(string)));
         }
-        
+
+        [Fact]
+        public void GetImplementsText_TypeNull_ExceptionThrown()
+        {
+            //arrange
+            var generatorOptionsProvider = new GeneratorOptionsProvider { GeneratorOptions = new GeneratorOptions() };
+            var tsContentGenerator = new TsContentGenerator(_typeDependencyService, _typeService, _templateService, _tsContentParser, _metadataReaderFactory, generatorOptionsProvider, null);
+
+            //act,assert
+            Assert.Throws<ArgumentNullException>(() => tsContentGenerator.GetImplementsText(null));
+        }
+
+        [Fact]
+        public void GetImplementsText_TypeNameConvertersNull_ExceptionThrown()
+        {
+            //arrange
+            var generatorOptionsProvider = new GeneratorOptionsProvider { GeneratorOptions = new GeneratorOptions { TypeNameConverters = null } };
+            var tsContentGenerator = new TsContentGenerator(_typeDependencyService, _typeService, _templateService, _tsContentParser, _metadataReaderFactory, generatorOptionsProvider, null);
+
+            //act,assert
+            Assert.Throws<ArgumentNullException>(() => tsContentGenerator.GetImplementsText(typeof(string)));
+        }
+
         [Fact]
         public void GetCustomBody_FilePathNull_ExceptionThrown()
         {

--- a/src/TypeGen/TypeGen.Core/Generator/Generator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Generator.cs
@@ -427,7 +427,12 @@ namespace TypeGen.Core.Generator
             var tsCustomBaseAttribute = _metadataReaderFactory.GetInstance().GetAttribute<TsCustomBaseAttribute>(type);
             var extendsText = "";
 
-            if (tsCustomBaseAttribute != null)
+            if (classAttribute == null)
+            {
+                // this is an interface, generate extends for an interface.
+                extendsText = _tsContentGenerator.GetExtendsForInterfacesText(type);
+            }
+            else if (tsCustomBaseAttribute != null)
             {
                 extendsText = string.IsNullOrEmpty(tsCustomBaseAttribute.Base) ? "" : _templateService.GetExtendsText(tsCustomBaseAttribute.Base);
             }
@@ -435,6 +440,8 @@ namespace TypeGen.Core.Generator
             {
                 extendsText = _tsContentGenerator.GetExtendsText(type);
             }
+
+            string implementsText = _tsContentGenerator.GetImplementsText(type);
 
             string importsText = _tsContentGenerator.GetImportsText(type, outputDir);
             string propertiesText = classAttribute != null ? GetClassPropertiesText(type) : GetInterfacePropertiesText(type);
@@ -453,8 +460,8 @@ namespace TypeGen.Core.Generator
             if (classAttribute != null)
             {
                 content = _typeService.UseDefaultExport(type) ?
-                    _templateService.FillClassDefaultExportTemplate(importsText, tsTypeName, tsTypeNameFirstPart, extendsText, propertiesText, customHead, customBody, Options.FileHeading) :
-                    _templateService.FillClassTemplate(importsText, tsTypeName, extendsText, propertiesText, customHead, customBody, Options.FileHeading);
+                    _templateService.FillClassDefaultExportTemplate(importsText, tsTypeName, tsTypeNameFirstPart, extendsText, implementsText, propertiesText, customHead, customBody, Options.FileHeading) :
+                    _templateService.FillClassTemplate(importsText, tsTypeName, extendsText, implementsText, propertiesText, customHead, customBody, Options.FileHeading);
             }
             else
             {

--- a/src/TypeGen/TypeGen.Core/Generator/Services/ITemplateService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/ITemplateService.cs
@@ -4,8 +4,8 @@ namespace TypeGen.Core.Generator.Services
 {
     internal interface ITemplateService
     {
-        string FillClassTemplate(string imports, string name, string extends, string properties, string customHead, string customBody, string fileHeading = null);
-        string FillClassDefaultExportTemplate(string imports, string name, string exportName, string extends, string properties, string customHead, string customBody, string fileHeading = null);
+        string FillClassTemplate(string imports, string name, string extends, string implements, string properties, string customHead, string customBody, string fileHeading = null);
+        string FillClassDefaultExportTemplate(string imports, string name, string exportName, string extends, string implements, string properties, string customHead, string customBody, string fileHeading = null);
         string FillClassPropertyTemplate(string modifiers, string name, string type, IEnumerable<string> typeUnions, string defaultValue = null);
         string FillInterfaceTemplate(string imports, string name, string extends, string properties, string customHead, string customBody, string fileHeading = null);
         string FillInterfaceDefaultExportTemplate(string imports, string name, string exportName, string extends, string properties, string customHead, string customBody, string fileHeading = null);
@@ -18,5 +18,7 @@ namespace TypeGen.Core.Generator.Services
         string FillIndexTemplate(string exports);
         string FillIndexExportTemplate(string filename);
         string GetExtendsText(string name);
+        string GetExtendsText(IEnumerable<string> name);
+        string GetImplementsText(IEnumerable<string> names);
     }
 }

--- a/src/TypeGen/TypeGen.Core/Generator/Services/ITsContentGenerator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/ITsContentGenerator.cs
@@ -44,5 +44,7 @@ namespace TypeGen.Core.Generator.Services
         /// <param name="memberInfo"></param>
         /// <returns>The text to be used as a member value. Null if the member has no value or value cannot be determined.</returns>
         string GetMemberValueText(MemberInfo memberInfo);
+        string GetImplementsText(Type type);
+        string GetExtendsForInterfacesText(Type type);
     }
 }

--- a/src/TypeGen/TypeGen.Core/Generator/Services/ITypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/ITypeService.cs
@@ -118,5 +118,6 @@ namespace TypeGen.Core.Generator.Services
         bool UseDefaultExport(Type type);
 
         IEnumerable<string> GetTypeUnions(MemberInfo memberInfo);
+        IEnumerable<Type> GetInterfaces(Type type);
     }
 }

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TemplateService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TemplateService.cs
@@ -54,7 +54,7 @@ namespace TypeGen.Core.Generator.Services
             _headingTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.Heading.tpl");
         }
 
-        public string FillClassTemplate(string imports, string name, string extends, string properties, string customHead, string customBody, string fileHeading = null)
+        public string FillClassTemplate(string imports, string name, string extends, string implements, string properties, string customHead, string customBody, string fileHeading = null)
         {
             if (fileHeading == null) fileHeading = _headingTemplate;
             
@@ -62,13 +62,14 @@ namespace TypeGen.Core.Generator.Services
                 .Replace(GetTag("imports"), imports)
                 .Replace(GetTag("name"), name)
                 .Replace(GetTag("extends"), extends)
+                .Replace(GetTag("implements"), implements)
                 .Replace(GetTag("properties"), properties)
                 .Replace(GetTag("customHead"), customHead)
                 .Replace(GetTag("customBody"), customBody)
                 .Replace(GetTag("fileHeading"), fileHeading);
         }
         
-        public string FillClassDefaultExportTemplate(string imports, string name, string exportName, string extends, string properties, string customHead, string customBody, string fileHeading = null)
+        public string FillClassDefaultExportTemplate(string imports, string name, string exportName, string extends, string implements, string properties, string customHead, string customBody, string fileHeading = null)
         {
             if (fileHeading == null) fileHeading = _headingTemplate;
             
@@ -77,6 +78,7 @@ namespace TypeGen.Core.Generator.Services
                 .Replace(GetTag("name"), name)
                 .Replace(GetTag("exportName"), exportName)
                 .Replace(GetTag("extends"), extends)
+                .Replace(GetTag("implements"), implements)
                 .Replace(GetTag("properties"), properties)
                 .Replace(GetTag("customHead"), customHead)
                 .Replace(GetTag("customBody"), customBody)
@@ -201,6 +203,9 @@ namespace TypeGen.Core.Generator.Services
         }
 
         public string GetExtendsText(string name) => $" extends {name}";
+        public string GetExtendsText(IEnumerable<string> names) => $" extends {string.Join(", ", names)}";
+
+        public string GetImplementsText(IEnumerable<string> names) => $" implements {string.Join(", ", names)}";
 
         private static string GetTag(string tagName) => $"$tg{{{tagName}}}";
 

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TsContentGenerator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TsContentGenerator.cs
@@ -91,6 +91,40 @@ namespace TypeGen.Core.Generator.Services
         }
 
         /// <summary>
+        /// Gets the text for the "extends" section for interfaces.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public string GetExtendsForInterfacesText(Type type)
+        {
+            Requires.NotNull(type, nameof(type));
+            Requires.NotNull(GeneratorOptions.TypeNameConverters, nameof(GeneratorOptions.TypeNameConverters));
+
+            IEnumerable<Type> baseTypes = _typeService.GetInterfaces(type);
+            if (!baseTypes.Any()) return "";
+
+            IEnumerable<string> baseTypeNames = baseTypes.Select(baseType => _typeService.GetTsTypeName(baseType, true));
+            return _templateService.GetExtendsText(baseTypeNames);
+        }
+
+        /// <summary>
+        /// Gets the text for the "implements" section
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public string GetImplementsText(Type type)
+        {
+            Requires.NotNull(type, nameof(type));
+            Requires.NotNull(GeneratorOptions.TypeNameConverters, nameof(GeneratorOptions.TypeNameConverters));
+
+            IEnumerable<Type> baseTypes = _typeService.GetInterfaces(type);
+            if (!baseTypes.Any()) return "";
+
+            IEnumerable<string> baseTypeNames = baseTypes.Select(baseType => _typeService.GetTsTypeName(baseType, true));
+            return _templateService.GetImplementsText(baseTypeNames);
+        }
+        
+        /// <summary>
         /// Returns TypeScript imports source code related to type dependencies
         /// </summary>
         /// <param name="type"></param>

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeDependencyService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeDependencyService.cs
@@ -43,8 +43,9 @@ namespace TypeGen.Core.Generator.Services
             type = _typeService.StripNullable(type);
 
             return GetGenericTypeDefinitionDependencies(type)
-                .Concat(GetBaseTypeDependency(type)
-                .Concat(GetMemberTypeDependencies(type)))
+                .Concat(GetBaseTypeDependency(type))
+                .Concat(GetInterfacesTypeDepency(type))
+                .Concat(GetMemberTypeDependencies(type))
                 .Distinct(new TypeDependencyInfoTypeComparer<TypeDependencyInfo>())
                 .ToList();
         }
@@ -88,6 +89,23 @@ namespace TypeGen.Core.Generator.Services
 
             return GetFlatTypeDependencies(baseType, null, true);
         }
+
+        /// <summary>
+        /// Gets implemented interfaces type dependency for a type, if the interfaces types exist
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        private IEnumerable<TypeDependencyInfo> GetInterfacesTypeDepency(Type type)
+        {
+            if (_metadataReaderFactory.GetInstance().GetAttribute<TsIgnoreBaseAttribute>(type) != null) return Enumerable.Empty<TypeDependencyInfo>();
+
+            var baseTypes = _typeService.GetInterfaces(type);
+            if (!baseTypes.Any()) return Enumerable.Empty<TypeDependencyInfo>();
+
+            return baseTypes
+                .SelectMany(baseType => GetFlatTypeDependencies(baseType, null, true));
+        }
+
 
         /// <summary>
         /// Gets type dependencies for the members inside a given type

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
@@ -495,5 +495,17 @@ namespace TypeGen.Core.Generator.Services
 
             return baseType;
         }
+
+        /// <inheritdoc />
+        public IEnumerable<Type> GetInterfaces(Type type)
+        {
+            Requires.NotNull(type, nameof(type));
+
+            IEnumerable<Type> baseTypes = type.GetTypeInfo().ImplementedInterfaces;
+
+            // if (IsTsClass(type) && IsTsInterface(baseType)) throw new CoreException($"Attempted to generate class '{type.FullName}' which extends an interface '{baseType.FullName}', which is not a valid inheritance chain in TypeScript");
+
+            return baseTypes;
+        }
     }
 }

--- a/src/TypeGen/TypeGen.Core/Templates/Class.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/Class.tpl
@@ -1,3 +1,3 @@
-$tg{fileHeading}$tg{imports}$tg{customHead}export class $tg{name}$tg{extends} {
+$tg{fileHeading}$tg{imports}$tg{customHead}export class $tg{name}$tg{extends}$tg{implements} {
 $tg{properties}$tg{customBody}
 }


### PR DESCRIPTION
Adding support for Interfaces implements and Interfaces extensions in the typescript templates.

Attempt to fix #98 .

It should cover cases like these:

## Foo.cs
```csharp
using System;
using TypeGen.Core.TypeAnnotations;

namespace foo
{
    [ExportTsClass]
    public class Foo : Bar, Car
    {
        public Car Car {get;set;}
        public string Far {get;set;}
    }

    public interface Bar : Far
    {

    }

    public interface Far
    {
        string Far {get;set;}
    }

    public interface Car
    {

    }
}
```

## bar.ts
```typescript
import { Far } from "./far";

export interface Bar extends Far {

}
```

## car.ts
```typescript
export interface Car {

}
```

## far.ts
```typescript
export interface Far {
    far: string;
}
```

## foo.ts
```typescript
import { Bar } from "./bar";
import { Far } from "./far";
import { Car } from "./car";

export class Foo implements Bar, Far, Car {
    car: Car;
    far: string;
}
```