### PR TITLE
New generation configuration option to apply TsNull by default.

### DIFF
--- a/src/TypeGen/TypeGen.Cli/Business/GeneratorOptionsProvider.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/GeneratorOptionsProvider.cs
@@ -45,7 +45,7 @@ namespace TypeGen.Cli.Business
             Requires.NotNullOrEmpty(projectFolder, nameof(projectFolder));
             
             _typeResolver = new TypeResolver(_logger, _fileSystem, projectFolder, assemblies);
-            
+
             return new GeneratorOptions
             {
                 TypeScriptFileExtension = config.TypeScriptFileExtension,
@@ -59,6 +59,7 @@ namespace TypeGen.Cli.Business
                 EnumValueNameConverters = GetMemberNameConvertersFromConfig(config.EnumValueNameConverters),
                 EnumStringInitializersConverters = GetMemberNameConvertersFromConfig(config.EnumStringInitializersConverters),
                 CsNullableTranslation = config.CsNullableTranslation.ToStrictNullFlags(),
+                CsAllowNullsForAllTypes = config.CsAllowNullsForAllTypes ?? GeneratorOptions.DefaultCsAllowNullsForAllTypes,
                 CreateIndexFile = config.CreateIndexFile ?? GeneratorOptions.DefaultCreateIndexFile,
                 DefaultValuesForTypes = config.DefaultValuesForTypes ?? GeneratorOptions.DefaultDefaultValuesForTypes,
                 TypeUnionsForTypes = config.TypeUnionsForTypes ?? GeneratorOptions.DefaultTypeUnionsForTypes,

--- a/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
+++ b/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
@@ -39,6 +39,7 @@ namespace TypeGen.Cli.Models
         public bool? ClearOutputDirectory { get; set; }
         public bool? CreateIndexFile { get; set; }
         public string CsNullableTranslation { get; set; }
+        public bool? CsAllowNullsForAllTypes { get; set; }
         public Dictionary<string, string> DefaultValuesForTypes { get; set; }
         public Dictionary<string, IEnumerable<string>> TypeUnionsForTypes { get; set; }
         public Dictionary<string, string> CustomTypeMappings { get; set; }
@@ -78,6 +79,7 @@ namespace TypeGen.Cli.Models
             if (ExternalAssemblyPaths == null) ExternalAssemblyPaths = new string[0];
             if (CreateIndexFile == null) CreateIndexFile = GeneratorOptions.DefaultCreateIndexFile;
             if (CsNullableTranslation == null) CsNullableTranslation = GeneratorOptions.DefaultCsNullableTranslation.ToFlagString();
+            if (CsAllowNullsForAllTypes == null) CsAllowNullsForAllTypes = GeneratorOptions.DefaultCsAllowNullsForAllTypes;
             if (OutputPath == null) OutputPath = "";
             if (ClearOutputDirectory == null) ClearOutputDirectory = false;
             if (DefaultValuesForTypes == null) DefaultValuesForTypes = GeneratorOptions.DefaultDefaultValuesForTypes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);

--- a/src/TypeGen/TypeGen.Core/Generator/GeneratorOptions.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/GeneratorOptions.cs
@@ -22,6 +22,7 @@ namespace TypeGen.Core.Generator
         public static bool DefaultSingleQuotes => false;
         public static bool DefaultCreateIndexFile => false;
         public static StrictNullTypeUnionFlags DefaultCsNullableTranslation => StrictNullTypeUnionFlags.None;
+        public static bool DefaultCsAllowNullsForAllTypes = false;
         public static IDictionary<string, string> DefaultDefaultValuesForTypes => new Dictionary<string, string>();
         public static IDictionary<string, IEnumerable<string>> DefaultTypeUnionsForTypes => new Dictionary<string, IEnumerable<string>>();
         public static IDictionary<string, string> DefaultCustomTypeMappings => new Dictionary<string, string>();
@@ -44,6 +45,7 @@ namespace TypeGen.Core.Generator
             SingleQuotes = DefaultSingleQuotes;
             CreateIndexFile = DefaultCreateIndexFile;
             CsNullableTranslation = DefaultCsNullableTranslation;
+            CsAllowNullsForAllTypes = DefaultCsAllowNullsForAllTypes;
             DefaultValuesForTypes = DefaultDefaultValuesForTypes;
             TypeUnionsForTypes = DefaultTypeUnionsForTypes;
             CustomTypeMappings = DefaultCustomTypeMappings;
@@ -124,6 +126,11 @@ namespace TypeGen.Core.Generator
         /// Indicates which union types (null, undefined) are added to TypeScript property types for C# nullable types by default
         /// </summary>
         public StrictNullTypeUnionFlags CsNullableTranslation { get; set; }
+
+        /// <summary>
+        /// Indicates to allow null for all types.
+        /// </summary>
+        public bool CsAllowNullsForAllTypes { get; set; }
 
         /// <summary>
         /// Specifies default values to generate for given TypeScript types

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
@@ -304,7 +304,8 @@ namespace TypeGen.Core.Generator.Services
                     result.AddRange(GeneratorOptions.TypeUnionsForTypes[tsTypeName]);
                 }
 
-                if (Nullable.GetUnderlyingType(memberType) != null && GeneratorOptions.CsNullableTranslation != StrictNullTypeUnionFlags.None)
+                if ((Nullable.GetUnderlyingType(memberType) != null && GeneratorOptions.CsNullableTranslation != StrictNullTypeUnionFlags.None) ||
+                        GeneratorOptions.CsAllowNullsForAllTypes)
                 {
                     if (GeneratorOptions.CsNullableTranslation.HasFlag(StrictNullTypeUnionFlags.Null)) result.Add(nullLiteral);
                     if (GeneratorOptions.CsNullableTranslation.HasFlag(StrictNullTypeUnionFlags.Undefined)) result.Add(undefinedLiteral);


### PR DESCRIPTION
(e.g.: foo: string | null;)

TypeGen allows an attribute `TsNull`, but one have to define it on every object properties.

I added an option to do this by default like so:

tsconfig.json:

```
{
  "CsAllowNullsForAllTypes": true
}
```