### PR TITLE
Add new 'optional' strict null type union flag

### DIFF
--- a/src/TypeGen/TypeGen.Cli.Test/Extensions/FlagExtensionsTest.cs
+++ b/src/TypeGen/TypeGen.Cli.Test/Extensions/FlagExtensionsTest.cs
@@ -22,8 +22,15 @@ namespace TypeGen.Cli.Test.Extensions
         [InlineData("asdff", StrictNullTypeUnionFlags.None)]
         [InlineData("null", StrictNullTypeUnionFlags.Null)]
         [InlineData("undefined", StrictNullTypeUnionFlags.Undefined)]
+        [InlineData("optional", StrictNullTypeUnionFlags.Optional)]
         [InlineData("null|undefined", StrictNullTypeUnionFlags.Null | StrictNullTypeUnionFlags.Undefined)]
         [InlineData("undefined|null", StrictNullTypeUnionFlags.Null | StrictNullTypeUnionFlags.Undefined)]
+        [InlineData("null|undefined|optional", StrictNullTypeUnionFlags.Null | StrictNullTypeUnionFlags.Undefined | StrictNullTypeUnionFlags.Optional)]
+        [InlineData("undefined|null|optional", StrictNullTypeUnionFlags.Undefined | StrictNullTypeUnionFlags.Null | StrictNullTypeUnionFlags.Optional)]
+        [InlineData("optional|null|undefined", StrictNullTypeUnionFlags.Optional | StrictNullTypeUnionFlags.Null | StrictNullTypeUnionFlags.Undefined)]
+        [InlineData("optional|undefined|null", StrictNullTypeUnionFlags.Optional | StrictNullTypeUnionFlags.Undefined | StrictNullTypeUnionFlags.Null)]
+        [InlineData("null|optional|undefined", StrictNullTypeUnionFlags.Null | StrictNullTypeUnionFlags.Optional | StrictNullTypeUnionFlags.Undefined)]
+        [InlineData("undefined|optional|null", StrictNullTypeUnionFlags.Undefined | StrictNullTypeUnionFlags.Optional | StrictNullTypeUnionFlags.Null)]
         [InlineData("undefined|null|sdfg", StrictNullTypeUnionFlags.Null | StrictNullTypeUnionFlags.Undefined)]
         public void ToStrictNullFlags_StringTranslationGiven_FlagsReturned(string input, StrictNullTypeUnionFlags expectedResult)
         {

--- a/src/TypeGen/TypeGen.Cli/Extensions/FlagExtensions.cs
+++ b/src/TypeGen/TypeGen.Cli/Extensions/FlagExtensions.cs
@@ -27,6 +27,7 @@ namespace TypeGen.Cli.Extensions
 
             if (parts.Contains("null")) result |= StrictNullTypeUnionFlags.Null;
             if (parts.Contains("undefined")) result |= StrictNullTypeUnionFlags.Undefined;
+            if (parts.Contains("optional")) result |= StrictNullTypeUnionFlags.Optional;
 
             return result;
         }

--- a/src/TypeGen/TypeGen.Core.Test/Generator/Services/TypeServiceTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/Generator/Services/TypeServiceTest.cs
@@ -390,6 +390,7 @@ namespace TypeGen.Core.Test.Generator.Services
             new object[] { typeof(GetTsTypeName_TestClass).GetField("nullableIntField"), new TypeNameConverterCollection(), StrictNullTypeUnionFlags.None, "number" },
             new object[] { typeof(GetTsTypeName_TestClass).GetField("nullableIntField"), new TypeNameConverterCollection(), StrictNullTypeUnionFlags.Null, "number" },
             new object[] { typeof(GetTsTypeName_TestClass).GetField("nullableIntField"), new TypeNameConverterCollection(), StrictNullTypeUnionFlags.Null | StrictNullTypeUnionFlags.Undefined, "number" },
+            new object[] { typeof(GetTsTypeName_TestClass).GetField("nullableIntField"), new TypeNameConverterCollection(), StrictNullTypeUnionFlags.Optional, "number" },
             new object[] { typeof(GetTsTypeName_TestClass).GetField("intNullField"), new TypeNameConverterCollection(), StrictNullTypeUnionFlags.Undefined, "number" },
             new object[] { typeof(GetTsTypeName_TestClass).GetField("intUndefinedField"), new TypeNameConverterCollection(), StrictNullTypeUnionFlags.Null, "number" },
             new object[] { typeof(GetTsTypeName_TestClass).GetField("intNullUndefinedField"), new TypeNameConverterCollection(), StrictNullTypeUnionFlags.Undefined, "number" },

--- a/src/TypeGen/TypeGen.Core/Generator/Services/ITemplateService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/ITemplateService.cs
@@ -6,7 +6,7 @@ namespace TypeGen.Core.Generator.Services
     {
         string FillClassTemplate(string imports, string name, string extends, string implements, string properties, string customHead, string customBody, string fileHeading = null);
         string FillClassDefaultExportTemplate(string imports, string name, string exportName, string extends, string implements, string properties, string customHead, string customBody, string fileHeading = null);
-        string FillClassPropertyTemplate(string modifiers, string name, string type, IEnumerable<string> typeUnions, string defaultValue = null);
+        string FillClassPropertyTemplate(string modifiers, string name, string type, IEnumerable<string> typeUnions, bool isOptional, string defaultValue = null);
         string FillInterfaceTemplate(string imports, string name, string extends, string properties, string customHead, string customBody, string fileHeading = null);
         string FillInterfaceDefaultExportTemplate(string imports, string name, string exportName, string extends, string properties, string customHead, string customBody, string fileHeading = null);
         string FillInterfacePropertyTemplate(string modifiers, string name, string type, IEnumerable<string> typeUnions, bool isOptional);

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TemplateService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TemplateService.cs
@@ -85,7 +85,7 @@ namespace TypeGen.Core.Generator.Services
                 .Replace(GetTag("fileHeading"), fileHeading);
         }
 
-        public string FillClassPropertyTemplate(string modifiers, string name, string type, IEnumerable<string> typeUnions, string defaultValue = null)
+        public string FillClassPropertyTemplate(string modifiers, string name, string type, IEnumerable<string> typeUnions, bool isOptional, string defaultValue = null)
         {
             type = $": {type}";
             type = ConcatenateWithTypeUnions(type, typeUnions);
@@ -94,7 +94,7 @@ namespace TypeGen.Core.Generator.Services
             
             return ReplaceSpecialChars(_classPropertyTemplate)
                 .Replace(GetTag("modifiers"), modifiers)
-                .Replace(GetTag("name"), name)
+                .Replace(GetTag("name"), name + (isOptional ? "?" : ""))
                 .Replace(GetTag("type"), type)
                 .Replace(GetTag("defaultValue"), defaultValue);
         }

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
@@ -315,7 +315,7 @@ namespace TypeGen.Core.Generator.Services
                     result.AddRange(GeneratorOptions.TypeUnionsForTypes[tsTypeName]);
                 }
 
-                if ((Nullable.GetUnderlyingType(memberType) != null && GeneratorOptions.CsNullableTranslation != StrictNullTypeUnionFlags.None) ||
+                if ((Nullable.GetUnderlyingType(memberType) != null && GeneratorOptions.CsNullableTranslation != StrictNullTypeUnionFlags.None && GeneratorOptions.CsNullableTranslation != StrictNullTypeUnionFlags.Optional) ||
                     GeneratorOptions.CsAllowNullsForAllTypes)
                 {
                     if (GeneratorOptions.CsNullableTranslation.HasFlag(StrictNullTypeUnionFlags.Null)) result.Add(nullLiteral);

--- a/src/TypeGen/TypeGen.Core/StrictNullTypeUnionFlags.cs
+++ b/src/TypeGen/TypeGen.Core/StrictNullTypeUnionFlags.cs
@@ -21,6 +21,11 @@ namespace TypeGen.Core
         /// <summary>
         /// Undefined
         /// </summary>
-        Undefined = 2
+        Undefined = 2,
+
+        /// <summary>
+        /// Optional
+        /// </summary>
+        Optional = 3
     }
 }


### PR DESCRIPTION
Addresses last post in https://github.com/jburzynski/TypeGen/issues/101

Adds a new option for `csNullableTranslation`, "optional". This causes generated member to have the TypeScript optional marker `?` instead of appending type unions.

```
class SomeClass {
    int?: NumberOfCoolThings { get; set; }
}
```

will generate as

```
class SomeClass {
    numberOfCoolThings?: number;
}
```