### PR TITLE
add new exception with initial type name

### DIFF
--- a/src/TypeGen/TypeGen.Core/Generator/Generator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Generator.cs
@@ -717,7 +717,15 @@ namespace TypeGen.Core.Generator
                     string defaultOutputDir = defaultOutputAttribute?.OutputDir ?? outputDir;
 
                     _generationContext.Add(typeDependency);
-                    generatedFiles.AddRange(GenerateNotMarked(typeDependency, defaultOutputDir));
+
+                    try
+                    {
+                        generatedFiles.AddRange(GenerateNotMarked(typeDependency, defaultOutputDir));
+                    }
+                    catch (CoreException ex)
+                    {
+                        throw new CoreException($"Error generating dependencies types for {type.FullName}", ex);
+                    }
                 }
             }
 

--- a/src/TypeGen/TypeGen.TestWebApp/TestEntities/TestExceptions.cs
+++ b/src/TypeGen/TypeGen.TestWebApp/TestEntities/TestExceptions.cs
@@ -1,0 +1,12 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using TypeGen.Core.TypeAnnotations;
+
+namespace TypeGen.TestWebApp.TestEntities
+{
+    public class TestExceptions
+    {
+        public List<Guid?>? InvalidCollection { get; set; }
+    }
+}


### PR DESCRIPTION
to assist with troubleshooting classes that fail to generate due to a dependency type failing I have added another exception that includes the initial type name and sets the inner exception to dependency type exception