### PR TITLE
Add default values for constants only option

### DIFF
--- a/src/TypeGen/TypeGen.Cli/Business/GeneratorOptionsProvider.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/GeneratorOptionsProvider.cs
@@ -60,6 +60,7 @@ namespace TypeGen.Cli.Business
                 EnumStringInitializersConverters = GetMemberNameConvertersFromConfig(config.EnumStringInitializersConverters),
                 CsNullableTranslation = config.CsNullableTranslation.ToStrictNullFlags(),
                 CsAllowNullsForAllTypes = config.CsAllowNullsForAllTypes ?? GeneratorOptions.DefaultCsAllowNullsForAllTypes,
+                CsDefaultValuesForConstantsOnly = config.CsDefaultValuesForConstantsOnly ?? GeneratorOptions.DefaultCsDefaultValuesForConstantsOnly,
                 CreateIndexFile = config.CreateIndexFile ?? GeneratorOptions.DefaultCreateIndexFile,
                 DefaultValuesForTypes = config.DefaultValuesForTypes ?? GeneratorOptions.DefaultDefaultValuesForTypes,
                 TypeUnionsForTypes = config.TypeUnionsForTypes ?? GeneratorOptions.DefaultTypeUnionsForTypes,

--- a/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
+++ b/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
@@ -40,6 +40,7 @@ namespace TypeGen.Cli.Models
         public bool? CreateIndexFile { get; set; }
         public string CsNullableTranslation { get; set; }
         public bool? CsAllowNullsForAllTypes { get; set; }
+        public bool? CsDefaultValuesForConstantsOnly { get; set; }
         public Dictionary<string, string> DefaultValuesForTypes { get; set; }
         public Dictionary<string, IEnumerable<string>> TypeUnionsForTypes { get; set; }
         public Dictionary<string, string> CustomTypeMappings { get; set; }
@@ -80,6 +81,7 @@ namespace TypeGen.Cli.Models
             if (CreateIndexFile == null) CreateIndexFile = GeneratorOptions.DefaultCreateIndexFile;
             if (CsNullableTranslation == null) CsNullableTranslation = GeneratorOptions.DefaultCsNullableTranslation.ToFlagString();
             if (CsAllowNullsForAllTypes == null) CsAllowNullsForAllTypes = GeneratorOptions.DefaultCsAllowNullsForAllTypes;
+            if (CsDefaultValuesForConstantsOnly == null) CsDefaultValuesForConstantsOnly = GeneratorOptions.DefaultCsDefaultValuesForConstantsOnly;
             if (OutputPath == null) OutputPath = "";
             if (ClearOutputDirectory == null) ClearOutputDirectory = false;
             if (DefaultValuesForTypes == null) DefaultValuesForTypes = GeneratorOptions.DefaultDefaultValuesForTypes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);

--- a/src/TypeGen/TypeGen.Core/Generator/GeneratorOptions.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/GeneratorOptions.cs
@@ -23,6 +23,7 @@ namespace TypeGen.Core.Generator
         public static bool DefaultCreateIndexFile => false;
         public static StrictNullTypeUnionFlags DefaultCsNullableTranslation => StrictNullTypeUnionFlags.None;
         public static bool DefaultCsAllowNullsForAllTypes = false;
+        public static bool DefaultCsDefaultValuesForConstantsOnly = false;
         public static IDictionary<string, string> DefaultDefaultValuesForTypes => new Dictionary<string, string>();
         public static IDictionary<string, IEnumerable<string>> DefaultTypeUnionsForTypes => new Dictionary<string, IEnumerable<string>>();
         public static IDictionary<string, string> DefaultCustomTypeMappings => new Dictionary<string, string>();
@@ -46,6 +47,7 @@ namespace TypeGen.Core.Generator
             CreateIndexFile = DefaultCreateIndexFile;
             CsNullableTranslation = DefaultCsNullableTranslation;
             CsAllowNullsForAllTypes = DefaultCsAllowNullsForAllTypes;
+            CsDefaultValuesForConstantsOnly = DefaultCsDefaultValuesForConstantsOnly;
             DefaultValuesForTypes = DefaultDefaultValuesForTypes;
             TypeUnionsForTypes = DefaultTypeUnionsForTypes;
             CustomTypeMappings = DefaultCustomTypeMappings;
@@ -131,6 +133,11 @@ namespace TypeGen.Core.Generator
         /// Specifies whether null union types should be added for all types
         /// </summary>
         public bool CsAllowNullsForAllTypes { get; set; }
+
+        /// <summary>
+        /// Specifies that only default values for constants are generated
+        /// </summary>
+        public bool CsDefaultValuesForConstantsOnly { get; set; }
 
         /// <summary>
         /// Specifies default values to generate for given TypeScript types

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TsContentGenerator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TsContentGenerator.cs
@@ -295,16 +295,21 @@ namespace TypeGen.Core.Generator.Services
                 object instance = memberInfo.IsStatic() ? null : ActivatorUtils.CreateInstanceAutoFillGenericParameters(memberInfo.DeclaringType);
                 var valueObj = new object();
                 object valueObjGuard = valueObj;
+                bool isConstant = false;
                 
                 switch (memberInfo)
                 {
                     case FieldInfo fieldInfo:
                         valueObj = fieldInfo.GetValue(instance);
+                        isConstant = fieldInfo.IsStatic && fieldInfo.IsLiteral && !fieldInfo.IsInitOnly;
                         break;
                     case PropertyInfo propertyInfo:
                         valueObj = propertyInfo.GetValue(instance);
                         break;
                 }
+
+                // if only default values for constants are allowed
+                if (GeneratorOptions.CsDefaultValuesForConstantsOnly && !isConstant) return null;
 
                 // if valueObj hasn't been assigned in the switch
                 if (valueObj == valueObjGuard) return null;

--- a/src/TypeGen/TypeGen.IntegrationTest/Generator/Expected/constants-only.ts
+++ b/src/TypeGen/TypeGen.IntegrationTest/Generator/Expected/constants-only.ts
@@ -1,0 +1,17 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export class ConstantsOnly {
+    fieldString: string;
+    fieldInt: number;
+    static staticString: string;
+    static staticInt: number;
+    static readonly staticReadonlyString: string;
+    static readonly staticReadonlyInt: number;
+    static readonly constString: string = "data";
+    static readonly constInt: number = 10;
+    propString: string;
+    propInt: number;
+}

--- a/src/TypeGen/TypeGen.IntegrationTest/TypeGen.IntegrationTest.csproj
+++ b/src/TypeGen/TypeGen.IntegrationTest/TypeGen.IntegrationTest.csproj
@@ -9,6 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <None Remove="Generator\Expected\constants-only.ts" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
 		<PackageReference Include="NSubstitute" Version="3.1.0" />
@@ -30,6 +34,7 @@
 		<EmbeddedResource Include="Generator\Expected\default-export\class-without-default-export.ts" />
 		<EmbeddedResource Include="Generator\Expected\default-export\generic-class-with-default-export.ts" />
 		<EmbeddedResource Include="Generator\Expected\default-export\interface-with-default-export.ts" />
+		<EmbeddedResource Include="Generator\Expected\constants-only.ts" />
 		<EmbeddedResource Include="Generator\Expected\default-member-values.ts" />
 		<EmbeddedResource Include="Generator\Expected\e-class.ts" />
 		<EmbeddedResource Include="Generator\Expected\extended-primitives-class.ts" />

--- a/src/TypeGen/TypeGen.TestWebApp/TestEntities/ConstantsOnly.cs
+++ b/src/TypeGen/TypeGen.TestWebApp/TestEntities/ConstantsOnly.cs
@@ -1,0 +1,23 @@
+using TypeGen.Core.TypeAnnotations;
+
+namespace TypeGen.TestWebApp.TestEntities
+{
+    [ExportTsClass]
+    public class ConstantsOnly
+    {
+        public const string ConstString = "data";
+        public const int ConstInt = 10;
+
+        public static string StaticString = "data";
+        public static int StaticInt = 10;
+
+        public static readonly string StaticReadonlyString = "data";
+        public static readonly int StaticReadonlyInt = 10;
+
+        public string FieldString = "data";
+        public int FieldInt = 10;
+
+        public string PropString { get; set; } = "data";
+        public int PropInt { get; set; } = 10;
+    }
+}


### PR DESCRIPTION
After running into various issues with the default serialized JSON values for classes producing TypeScript errors, I added an option to only set default values for constants.

 