### PR TITLE
fixed nullable detection of string? when CsNullableTranslation enabled

### DIFF
--- a/src/TypeGen/TypeGen.Core/Extensions/TypeExtensions.cs
+++ b/src/TypeGen/TypeGen.Core/Extensions/TypeExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Namotion.Reflection;
 using TypeGen.Core.Metadata;
 using TypeGen.Core.TypeAnnotations;
 using TypeGen.Core.Validation;
@@ -93,6 +94,19 @@ namespace TypeGen.Core.Extensions
             if (memberInfo is PropertyInfo propertyInfo) return propertyInfo.GetMethod.IsStatic;
 
             return false;
+        }
+
+        /// <summary>
+        /// Checks if a property or field is nullable
+        /// </summary>
+        /// <param name="memberInfo"></param>
+        /// <returns></returns>
+        public static bool IsNullable(this MemberInfo memberInfo)
+        {
+            Requires.NotNull(memberInfo, nameof(memberInfo));
+
+            var contextualMember = memberInfo.ToContextualAccessor();
+            return contextualMember.Nullability == Nullability.Nullable;
         }
 
         /// <summary>

--- a/src/TypeGen/TypeGen.Core/Generator/Generator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Generator.cs
@@ -535,7 +535,7 @@ namespace TypeGen.Core.Generator
             IEnumerable<string> typeUnions = _typeService.GetTypeUnions(memberInfo);
 
             bool isOptional = _metadataReaderFactory.GetInstance().GetAttribute<TsOptionalAttribute>(memberInfo) != null;
-            var isNullable = memberInfo is PropertyInfo info ? Nullable.GetUnderlyingType(info.PropertyType) != null : false;
+            var isNullable = memberInfo.IsNullable();
             if (isNullable && Options.CsNullableTranslation == StrictNullTypeUnionFlags.Optional)
             {
                 isOptional = true;
@@ -603,7 +603,7 @@ namespace TypeGen.Core.Generator
             IEnumerable<string> typeUnions = _typeService.GetTypeUnions(memberInfo);
             
             bool isOptional = _metadataReaderFactory.GetInstance().GetAttribute<TsOptionalAttribute>(memberInfo) != null;
-            var isNullable = memberInfo is PropertyInfo info ? Nullable.GetUnderlyingType(info.PropertyType) != null : false;
+            var isNullable = memberInfo.IsNullable();
             if (isNullable && Options.CsNullableTranslation == StrictNullTypeUnionFlags.Optional)
             {
                 isOptional = true;

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
@@ -319,19 +319,7 @@ namespace TypeGen.Core.Generator.Services
                     result.AddRange(GeneratorOptions.TypeUnionsForTypes[tsTypeName]);
                 }
 
-#if NET6_0_OR_GREATER
-                var memberNullability = memberInfo switch {
-                    PropertyInfo pInfo => _nullabilityContext.Create(pInfo),
-                    FieldInfo fInfo => _nullabilityContext.Create(fInfo),
-                    EventInfo eInfo => _nullabilityContext.Create(eInfo),
-                    _ => null
-                };
-
-                var nullable = memberNullability != null ? new[] { memberNullability.ReadState, memberNullability.WriteState }.Any(i => new[] { NullabilityState.Nullable, NullabilityState.Unknown }.Contains(i))
-                    : Nullable.GetUnderlyingType(memberType) != null;
-#else
-                var nullable = Nullable.GetUnderlyingType(memberType) != null;
-#endif
+                var nullable = memberInfo.IsNullable();
 
                 if ((nullable && GeneratorOptions.CsNullableTranslation != StrictNullTypeUnionFlags.None && GeneratorOptions.CsNullableTranslation != StrictNullTypeUnionFlags.Optional) ||
                     GeneratorOptions.CsAllowNullsForAllTypes)

--- a/src/TypeGen/TypeGen.Core/TypeGen.Core.csproj
+++ b/src/TypeGen/TypeGen.Core/TypeGen.Core.csproj
@@ -34,6 +34,7 @@
     <EmbeddedResource Include="Templates\IndexExport.tpl" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Namotion.Reflection" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />

--- a/src/TypeGen/TypeGen.IntegrationTest/Generator/Expected/nullable-class.ts
+++ b/src/TypeGen/TypeGen.IntegrationTest/Generator/Expected/nullable-class.ts
@@ -1,0 +1,17 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export class NullableClass {
+    numberNotNullable: number;
+    numberNullable?: number;
+    stringNotNullable: string = "";
+    stringNullable?: string;
+    guidNotNullable: string;
+    guidNullable?: string;
+    listNotNullable: string[] = [];
+    listNullable?: string[];
+    dictionaryNotNullable: { [key: string]: string; } = {};
+    dictionaryNullable?: { [key: string]: string; };
+}

--- a/src/TypeGen/TypeGen.IntegrationTest/Generator/GeneratorTest.cs
+++ b/src/TypeGen/TypeGen.IntegrationTest/Generator/GeneratorTest.cs
@@ -100,6 +100,29 @@ namespace TypeGen.IntegrationTest.Generator
             Assert.Equal(expected, FormatOutput(interceptor.GeneratedOutputs[type].Content));
         }
 
+        [Theory]
+        [InlineData(typeof(TestEntities.NullableClass), "TypeGen.IntegrationTest.Generator.Expected.nullable-class.ts")]
+        public async Task TestNullableTranslationGenerateSpec(Type type, string expectedLocation)
+        {
+            var readExpectedTask = EmbededResourceReader.GetEmbeddedResourceAsync(expectedLocation);
+
+            var spec = new TestNullableTranslationGenerationSpec();
+            var generator = new Gen.Generator()
+            {
+                Options =
+                {
+                    CsNullableTranslation = Core.StrictNullTypeUnionFlags.Optional
+                }
+            };
+            var interceptor = GeneratorOutputInterceptor.CreateInterceptor(generator);
+
+            await generator.GenerateAsync(new[] { spec });
+            var expected = (await readExpectedTask).Trim();
+
+            Assert.True(interceptor.GeneratedOutputs.ContainsKey(type));
+            Assert.Equal(expected, FormatOutput(interceptor.GeneratedOutputs[type].Content));
+        }
+
         private string FormatOutput(string output) 
             => output
                 .Trim()
@@ -126,6 +149,14 @@ namespace TypeGen.IntegrationTest.Generator
                 AddClass(typeof(TestEntities.GenericWithRestrictions<>));
                 AddClass<TestEntities.LiteDbEntity>().Member(nameof(TestEntities.LiteDbEntity.MyBsonArray)).Ignore();
                 AddInterface<TestEntities.NestedEntity>("./very/nested/directory/").Member(nameof(TestEntities.NestedEntity.OptionalProperty)).Optional();
+            }
+        }
+
+        private class TestNullableTranslationGenerationSpec : GenerationSpec
+        {
+            public TestNullableTranslationGenerationSpec()
+            {
+                AddClass<TestEntities.NullableClass>();
             }
         }
     }

--- a/src/TypeGen/TypeGen.IntegrationTest/TypeGen.IntegrationTest.csproj
+++ b/src/TypeGen/TypeGen.IntegrationTest/TypeGen.IntegrationTest.csproj
@@ -44,6 +44,7 @@
 		<EmbeddedResource Include="Generator\Expected\index.ts" />
 		<EmbeddedResource Include="Generator\Expected\lite-db-entity.ts" />
 		<EmbeddedResource Include="Generator\Expected\no\slash\output\dir\no-slash-output-dir.ts" />
+		<EmbeddedResource Include="Generator\Expected\nullable-class.ts" />
 		<EmbeddedResource Include="Generator\Expected\readonly-interface.ts" />
 		<EmbeddedResource Include="Generator\Expected\standalone-enum.ts" />
 		<EmbeddedResource Include="Generator\Expected\strict-nulls-class.ts" />

--- a/src/TypeGen/TypeGen.TestWebApp/TestEntities/NullableClass.cs
+++ b/src/TypeGen/TypeGen.TestWebApp/TestEntities/NullableClass.cs
@@ -1,0 +1,26 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using TypeGen.Core.TypeAnnotations;
+
+namespace TypeGen.TestWebApp.TestEntities
+{
+    [ExportTsClass]
+    public class NullableClass
+    {
+        public int NumberNotNullable { get; set; }
+        public int? NumberNullable { get; set; }
+
+        public string StringNotNullable { get; set; } = string.Empty;
+        public string? StringNullable { get; set; }
+
+        public Guid GuidNotNullable { get; set; }
+        public Guid? GuidNullable { get; set; }
+
+        public List<string> ListNotNullable { get; set; } = new();
+        public List<string>? ListNullable { get; set; }
+
+        public Dictionary<string, string> DictionaryNotNullable { get; set; } = new();
+        public Dictionary<string, string>? DictionaryNullable { get; set; }
+    }
+}


### PR DESCRIPTION
the current nullable detection logic did not work for nullable strings (string?), I have added an extension IsNullable that uses a 3rd party library to help detect nullability correctly