### PR TITLE
Add type generation for structs

### DIFF
--- a/src/TypeGen/TypeGen.Core.Test/SpecGeneration/Generic/StructSpecBuilderTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/SpecGeneration/Generic/StructSpecBuilderTest.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Linq;
+using TypeGen.Core.SpecGeneration;
+using TypeGen.Core.TypeAnnotations;
+using Xunit;
+
+namespace TypeGen.Core.Test.SpecGeneration.Generic
+{
+    public class StructSpecBuilderTest
+    {
+        private struct ExportedStruct
+        {
+            public string member;
+        }
+        
+        [Fact]
+        public void Member_Invoked_MemberAddedToSpec()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member);
+
+            Assert.True(spec.MemberAttributes.ContainsKey(member));
+        }
+        
+        [Fact]
+        public void Member_AttributesSpecifiedForMember_AttributesAddedToCorrectMember()
+        {
+            const string member1 = "member1";
+            const string member2 = "member2";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member1).Ignore().Member(member2).Null();
+
+            Attribute attribute1 = spec.MemberAttributes[member1].FirstOrDefault();
+            Attribute attribute2 = spec.MemberAttributes[member2].FirstOrDefault();
+            Assert.IsType<TsIgnoreAttribute>(attribute1);
+            Assert.IsType<TsNullAttribute>(attribute2);
+        }
+        
+        
+        [Fact]
+        public void Member_FuncGiven_MemberAddedToSpec()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(x => nameof(x.member));
+
+            Assert.True(spec.MemberAttributes.ContainsKey(member));
+        }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DefaultExport_Invoked_SpecUpdated(bool enabled)
+        {
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.DefaultExport(enabled);
+
+            Attribute attribute = spec.AdditionalAttributes.FirstOrDefault();
+            Assert.IsType<TsDefaultExportAttribute>(attribute);
+            Assert.Equal(enabled, ((TsDefaultExportAttribute)attribute).Enabled);
+        }
+        
+        [Fact]
+        public void DefaultTypeOutput_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            const string outputDir = "outputDir";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).DefaultTypeOutput(outputDir);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsDefaultTypeOutputAttribute>(attribute);
+            Assert.Equal(outputDir, ((TsDefaultTypeOutputAttribute)attribute).OutputDir);
+        }
+        
+        [Fact]
+        public void DefaultValue_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            const string defaultValue = "defaultValue";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).DefaultValue(defaultValue);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsDefaultValueAttribute>(attribute);
+            Assert.Equal(defaultValue, ((TsDefaultValueAttribute)attribute).DefaultValue);
+        }
+        
+        [Fact]
+        public void Ignore_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).Ignore();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsIgnoreAttribute>(attribute);
+        }
+        
+        [Fact]
+        public void IgnoreBase_Invoked_SpecUpdated()
+        {
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.IgnoreBase();
+
+            Attribute attribute = spec.AdditionalAttributes.FirstOrDefault();
+            Assert.IsType<TsIgnoreBaseAttribute>(attribute);
+        }
+        
+        [Fact]
+        public void MemberName_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            const string name = "name";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).MemberName(name);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsMemberNameAttribute>(attribute);
+            Assert.Equal(name, ((TsMemberNameAttribute)attribute).Name);
+        }
+        
+        [Fact]
+        public void NotNull_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).NotNull();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsNotNullAttribute>(attribute);
+        }
+        
+        [Fact]
+        public void NotStatic_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).NotStatic();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsNotStaticAttribute>(attribute);
+        }
+        
+        [Fact]
+        public void NotUndefined_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).NotUndefined();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsNotUndefinedAttribute>(attribute);
+        }
+        
+        [Fact]
+        public void Null_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).Null();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsNullAttribute>(attribute);
+        }
+        
+        [Fact]
+        public void Static_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).Static();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsStaticAttribute>(attribute);
+        }
+        
+        [Fact]
+        public void Type_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            const string typeName = "typeName";
+            const string importPath = "importPath";
+            const string originalTypeName = "originalTypeName";
+            const bool isDefaultExport = true;
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).Type(typeName, importPath, originalTypeName, isDefaultExport);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsTypeAttribute>(attribute);
+            Assert.Equal(typeName, ((TsTypeAttribute)attribute).TypeName);
+            Assert.Equal(importPath, ((TsTypeAttribute)attribute).ImportPath);
+            Assert.Equal(originalTypeName, ((TsTypeAttribute)attribute).OriginalTypeName);
+            Assert.Equal(isDefaultExport, ((TsTypeAttribute)attribute).IsDefaultExport);
+        }
+        
+        [Fact]
+        public void TypeUnions_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            string[] typeUnions = { "null", "undefined" };
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).TypeUnions(typeUnions);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsTypeUnionsAttribute>(attribute);
+            Assert.Same(typeUnions, ((TsTypeUnionsAttribute)attribute).TypeUnions);
+        }
+        
+        [Fact]
+        public void Undefined_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new TypeGen.Core.SpecGeneration.Generic.StructSpecBuilder<ExportedStruct>(spec);
+
+            builder.Member(member).Undefined();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsUndefinedAttribute>(attribute);
+        }
+    }
+}

--- a/src/TypeGen/TypeGen.Core.Test/SpecGeneration/StructSpecBuilderTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/SpecGeneration/StructSpecBuilderTest.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Linq;
+using TypeGen.Core.SpecGeneration;
+using TypeGen.Core.SpecGeneration.Generic;
+using TypeGen.Core.TypeAnnotations;
+using Xunit;
+
+namespace TypeGen.Core.Test.SpecGeneration
+{
+
+    public class StructSpecBuilderTest
+    {
+
+        [Fact]
+        public void Member_Invoked_MemberAddedToSpec()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member);
+
+            Assert.True(spec.MemberAttributes.ContainsKey(member));
+        }
+
+        [Fact]
+        public void Member_AttributesSpecifiedForMember_AttributesAddedToCorrectMember()
+        {
+            const string member1 = "member1";
+            const string member2 = "member2";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member1).Ignore().Member(member2).Null();
+
+            Attribute attribute1 = spec.MemberAttributes[member1].FirstOrDefault();
+            Attribute attribute2 = spec.MemberAttributes[member2].FirstOrDefault();
+            Assert.IsType<TsIgnoreAttribute>(attribute1);
+            Assert.IsType<TsNullAttribute>(attribute2);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DefaultExport_Invoked_SpecUpdated(bool enabled)
+        {
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.DefaultExport(enabled);
+
+            Attribute attribute = spec.AdditionalAttributes.FirstOrDefault();
+            Assert.IsType<TsDefaultExportAttribute>(attribute);
+            Assert.Equal(enabled, ((TsDefaultExportAttribute) attribute).Enabled);
+        }
+
+        [Fact]
+        public void DefaultTypeOutput_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            const string outputDir = "outputDir";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).DefaultTypeOutput(outputDir);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsDefaultTypeOutputAttribute>(attribute);
+            Assert.Equal(outputDir, ((TsDefaultTypeOutputAttribute) attribute).OutputDir);
+        }
+
+        [Fact]
+        public void DefaultValue_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            const string defaultValue = "defaultValue";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).DefaultValue(defaultValue);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsDefaultValueAttribute>(attribute);
+            Assert.Equal(defaultValue, ((TsDefaultValueAttribute) attribute).DefaultValue);
+        }
+
+        [Fact]
+        public void Ignore_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).Ignore();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsIgnoreAttribute>(attribute);
+        }
+
+        [Fact]
+        public void IgnoreBase_Invoked_SpecUpdated()
+        {
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.IgnoreBase();
+
+            Attribute attribute = spec.AdditionalAttributes.FirstOrDefault();
+            Assert.IsType<TsIgnoreBaseAttribute>(attribute);
+        }
+
+        [Fact]
+        public void MemberName_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            const string name = "name";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).MemberName(name);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsMemberNameAttribute>(attribute);
+            Assert.Equal(name, ((TsMemberNameAttribute) attribute).Name);
+        }
+
+        [Fact]
+        public void NotNull_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).NotNull();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsNotNullAttribute>(attribute);
+        }
+
+        [Fact]
+        public void NotStatic_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).NotStatic();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsNotStaticAttribute>(attribute);
+        }
+
+        [Fact]
+        public void NotUndefined_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).NotUndefined();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsNotUndefinedAttribute>(attribute);
+        }
+
+        [Fact]
+        public void Null_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).Null();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsNullAttribute>(attribute);
+        }
+
+        [Fact]
+        public void Static_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).Static();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsStaticAttribute>(attribute);
+        }
+
+        [Fact]
+        public void Type_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            const string typeName = "typeName";
+            const string importPath = "importPath";
+            const string originalTypeName = "originalTypeName";
+            const bool isDefaultExport = true;
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).Type(typeName, importPath, originalTypeName, isDefaultExport);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsTypeAttribute>(attribute);
+            Assert.Equal(typeName, ((TsTypeAttribute) attribute).TypeName);
+            Assert.Equal(importPath, ((TsTypeAttribute) attribute).ImportPath);
+            Assert.Equal(originalTypeName, ((TsTypeAttribute) attribute).OriginalTypeName);
+            Assert.Equal(isDefaultExport, ((TsTypeAttribute) attribute).IsDefaultExport);
+        }
+
+        [Fact]
+        public void TypeUnions_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            string[] typeUnions = {"null", "undefined"};
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).TypeUnions(typeUnions);
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsTypeUnionsAttribute>(attribute);
+            Assert.Same(typeUnions, ((TsTypeUnionsAttribute) attribute).TypeUnions);
+        }
+
+        [Fact]
+        public void Undefined_Invoked_SpecUpdated()
+        {
+            const string member = "member";
+            var spec = new TypeSpec(new ExportTsStructAttribute());
+            var builder = new StructSpecBuilder(spec);
+
+            builder.Member(member).Undefined();
+
+            Attribute attribute = spec.MemberAttributes[member].FirstOrDefault();
+            Assert.IsType<TsUndefinedAttribute>(attribute);
+        }
+    }
+}

--- a/src/TypeGen/TypeGen.Core/Extensions/TypeExtensions.cs
+++ b/src/TypeGen/TypeGen.Core/Extensions/TypeExtensions.cs
@@ -25,6 +25,7 @@ namespace TypeGen.Core.Extensions
             
             return reader.GetAttribute<ExportTsClassAttribute>(type) != null ||
                    reader.GetAttribute<ExportTsInterfaceAttribute>(type) != null ||
+                   reader.GetAttribute<ExportTsStructAttribute>(type) != null ||
                    reader.GetAttribute<ExportTsEnumAttribute>(type) != null;
         }
 
@@ -137,7 +138,7 @@ namespace TypeGen.Core.Extensions
             Requires.NotNull(type, nameof(type));
             TypeInfo typeInfo = type.GetTypeInfo();
 
-            if (!typeInfo.IsClass && !typeInfo.IsInterface) return Enumerable.Empty<MemberInfo>();
+            if (!typeInfo.IsClass && !typeInfo.IsInterface && !typeInfo.IsValueType) return Enumerable.Empty<MemberInfo>();
 
             var fieldInfos = (IEnumerable<MemberInfo>) typeInfo.DeclaredFields
                 .WithMembersFilter();

--- a/src/TypeGen/TypeGen.Core/Generator/Services/GenerationSpecProvider.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/GenerationSpecProvider.cs
@@ -23,7 +23,7 @@ namespace TypeGen.Core.Generator.Services
             foreach (Assembly assembly in assemblies)
             {
                 IEnumerable<Type> types = assembly.GetLoadableTypes()
-                    .GetExportMarkedTypes(metadataReader);
+                    .GetExportMarkedTypes(metadataReader).ToList();
 
                 foreach (Type type in types)
                 {

--- a/src/TypeGen/TypeGen.Core/SpecGeneration/ClassOrInterfaceOrStructSpecBuilder.cs
+++ b/src/TypeGen/TypeGen.Core/SpecGeneration/ClassOrInterfaceOrStructSpecBuilder.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using TypeGen.Core.TypeAnnotations;
+
+namespace TypeGen.Core.SpecGeneration
+{
+    /// <summary>
+    /// Base class for class, interface and struct spec builders
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TDerived"></typeparam>
+    public abstract class ClassOrInterfaceOrStructSpecBuilder<T, TDerived> : TypeSpecBuilder<T, TDerived> where TDerived : ClassOrInterfaceOrStructSpecBuilder<T, TDerived>
+    {
+        internal ClassOrInterfaceOrStructSpecBuilder(TypeSpec spec) : base(spec) { }
+
+        /// <summary>
+        /// Indicates whether to use default export for the generated TypeScript type (equivalent of TsDefaultExportAttribute)
+        /// </summary>
+        /// <param name="enabled"></param>
+        /// <returns></returns>
+        public TDerived DefaultExport(bool enabled = true)
+        {
+            AddTypeAttribute(new TsDefaultExportAttribute(enabled));
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Specifies the default type output path for the selected member (equivalent of TsDefaultTypeOutputAttribute)
+        /// </summary>
+        /// <param name="outputDir"></param>
+        /// <returns></returns>
+        public TDerived DefaultTypeOutput(string outputDir)
+        {
+            AddActiveMemberAttribute(new TsDefaultTypeOutputAttribute(outputDir));
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Specifies default value for the selected member (equivalent of TsDefaultValueAttribute)
+        /// </summary>
+        /// <param name="defaultValue"></param>
+        /// <returns></returns>
+        public TDerived DefaultValue(string defaultValue)
+        {
+            AddActiveMemberAttribute(new TsDefaultValueAttribute(defaultValue));
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Marks selected member as ignored (equivalent of TsIgnoreAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived Ignore()
+        {
+            AddActiveMemberAttribute(new TsIgnoreAttribute());
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Indicates whether to ignore base class declaration for type (equivalent of TsIgnoreBaseAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived IgnoreBase()
+        {
+            AddTypeAttribute(new TsIgnoreBaseAttribute());
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Specifies name for the selected member (equivalent of TsMemberNameAttribute)
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public TDerived MemberName(string name)
+        {
+            AddActiveMemberAttribute(new TsMemberNameAttribute(name));
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Marks selected member as not null (equivalent of TsNotNullAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived NotNull()
+        {
+            AddActiveMemberAttribute(new TsNotNullAttribute());
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Marks selected member as not readonly (equivalent of TsNotReadonlyAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived NotReadonly()
+        {
+            AddActiveMemberAttribute(new TsNotReadonlyAttribute());
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Marks selected member as not undefined (equivalent of TsNotUndefinedAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived NotUndefined()
+        {
+            AddActiveMemberAttribute(new TsNotUndefinedAttribute());
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Marks selected member as null (equivalent of TsNullAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived Null()
+        {
+            AddActiveMemberAttribute(new TsNullAttribute());
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Marks selected member as readonly (equivalent of TsReadonlyAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived Readonly()
+        {
+            AddActiveMemberAttribute(new TsReadonlyAttribute());
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Specifies custom type for the selected member (equivalent of TsTypeAttribute)
+        /// </summary>
+        /// <param name="typeName"></param>
+        /// <param name="importPath"></param>
+        /// <param name="originalTypeName"></param>
+        /// <param name="isDefaultExport"></param>
+        /// <returns></returns>
+        public TDerived Type(string typeName, string importPath = null, string originalTypeName = null, bool isDefaultExport = false)
+        {
+            AddActiveMemberAttribute(new TsTypeAttribute(typeName, importPath, originalTypeName, isDefaultExport));
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Specifies custom type for the selected member (equivalent of TsTypeAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived Type(TsType tsType)
+        {
+            AddActiveMemberAttribute(new TsTypeAttribute(tsType));
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Specifies TypeScript type unions (excluding the main type) for a property or field (equivalent of TsTypeUnionsAttribute)
+        /// </summary>
+        /// <param name="typeUnions"></param>
+        /// <returns></returns>
+        public TDerived TypeUnions(IEnumerable<string> typeUnions)
+        {
+            AddActiveMemberAttribute(new TsTypeUnionsAttribute(typeUnions));
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Specifies TypeScript type unions (excluding the main type) for a property or field (equivalent of TsTypeUnionsAttribute)
+        /// </summary>
+        /// <param name="typeUnions"></param>
+        /// <returns></returns>
+        public TDerived TypeUnions(params string[] typeUnions)
+        {
+            AddActiveMemberAttribute(new TsTypeUnionsAttribute(typeUnions));
+            return this as TDerived;
+        }
+
+        /// <summary>
+        /// Marks selected member as undefined (equivalent of TsUndefinedAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public TDerived Undefined()
+        {
+            AddActiveMemberAttribute(new TsUndefinedAttribute());
+            return this as TDerived;
+        }
+    }
+}

--- a/src/TypeGen/TypeGen.Core/SpecGeneration/ClassOrInterfaceSpecBuilder.cs
+++ b/src/TypeGen/TypeGen.Core/SpecGeneration/ClassOrInterfaceSpecBuilder.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using TypeGen.Core.TypeAnnotations;
 
 namespace TypeGen.Core.SpecGeneration
@@ -8,12 +7,12 @@ namespace TypeGen.Core.SpecGeneration
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <typeparam name="TDerived"></typeparam>
-    public abstract class ClassOrInterfaceSpecBuilder<T, TDerived> : TypeSpecBuilder<T, TDerived> where TDerived : ClassOrInterfaceSpecBuilder<T, TDerived>
+    public abstract class ClassOrInterfaceSpecBuilder<T, TDerived> : ClassOrInterfaceOrStructSpecBuilder<T, TDerived> where TDerived : ClassOrInterfaceSpecBuilder<T, TDerived>
     {
         internal ClassOrInterfaceSpecBuilder(TypeSpec spec) : base(spec)
         {
         }
-
+        
         /// <summary>
         /// Specifies custom base for the type (equivalent of TsCustomBaseAttribute)
         /// </summary>
@@ -27,175 +26,6 @@ namespace TypeGen.Core.SpecGeneration
             AddTypeAttribute(new TsCustomBaseAttribute(@base, importPath, originalTypeName, isDefaultExport));
             return this as TDerived;
         }
-        
-        /// <summary>
-        /// Indicates whether to use default export for the generated TypeScript type (equivalent of TsDefaultExportAttribute)
-        /// </summary>
-        /// <param name="enabled"></param>
-        /// <returns></returns>
-        public TDerived DefaultExport(bool enabled = true)
-        {
-            AddTypeAttribute(new TsDefaultExportAttribute(enabled));
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Specifies the default type output path for the selected member (equivalent of TsDefaultTypeOutputAttribute)
-        /// </summary>
-        /// <param name="outputDir"></param>
-        /// <returns></returns>
-        public TDerived DefaultTypeOutput(string outputDir)
-        {
-            AddActiveMemberAttribute(new TsDefaultTypeOutputAttribute(outputDir));
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Specifies default value for the selected member (equivalent of TsDefaultValueAttribute)
-        /// </summary>
-        /// <param name="defaultValue"></param>
-        /// <returns></returns>
-        public TDerived DefaultValue(string defaultValue)
-        {
-            AddActiveMemberAttribute(new TsDefaultValueAttribute(defaultValue));
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Marks selected member as ignored (equivalent of TsIgnoreAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived Ignore()
-        {
-            AddActiveMemberAttribute(new TsIgnoreAttribute());
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Indicates whether to ignore base class declaration for type (equivalent of TsIgnoreBaseAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived IgnoreBase()
-        {
-            AddTypeAttribute(new TsIgnoreBaseAttribute());
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Specifies name for the selected member (equivalent of TsMemberNameAttribute)
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public TDerived MemberName(string name)
-        {
-            AddActiveMemberAttribute(new TsMemberNameAttribute(name));
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Marks selected member as not null (equivalent of TsNotNullAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived NotNull()
-        {
-            AddActiveMemberAttribute(new TsNotNullAttribute());
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Marks selected member as not readonly (equivalent of TsNotReadonlyAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived NotReadonly()
-        {
-            AddActiveMemberAttribute(new TsNotReadonlyAttribute());
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Marks selected member as not undefined (equivalent of TsNotUndefinedAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived NotUndefined()
-        {
-            AddActiveMemberAttribute(new TsNotUndefinedAttribute());
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Marks selected member as null (equivalent of TsNullAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived Null()
-        {
-            AddActiveMemberAttribute(new TsNullAttribute());
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Marks selected member as readonly (equivalent of TsReadonlyAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived Readonly()
-        {
-            AddActiveMemberAttribute(new TsReadonlyAttribute());
-            return this as TDerived;
-        }
 
-        /// <summary>
-        /// Specifies custom type for the selected member (equivalent of TsTypeAttribute)
-        /// </summary>
-        /// <param name="typeName"></param>
-        /// <param name="importPath"></param>
-        /// <param name="originalTypeName"></param>
-        /// <param name="isDefaultExport"></param>
-        /// <returns></returns>
-        public TDerived Type(string typeName, string importPath = null, string originalTypeName = null, bool isDefaultExport = false)
-        {
-            AddActiveMemberAttribute(new TsTypeAttribute(typeName, importPath, originalTypeName, isDefaultExport));
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Specifies custom type for the selected member (equivalent of TsTypeAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived Type(TsType tsType)
-        {
-            AddActiveMemberAttribute(new TsTypeAttribute(tsType));
-            return this as TDerived;
-        }
-
-        /// <summary>
-        /// Specifies TypeScript type unions (excluding the main type) for a property or field (equivalent of TsTypeUnionsAttribute)
-        /// </summary>
-        /// <param name="typeUnions"></param>
-        /// <returns></returns>
-        public TDerived TypeUnions(IEnumerable<string> typeUnions)
-        {
-            AddActiveMemberAttribute(new TsTypeUnionsAttribute(typeUnions));
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Specifies TypeScript type unions (excluding the main type) for a property or field (equivalent of TsTypeUnionsAttribute)
-        /// </summary>
-        /// <param name="typeUnions"></param>
-        /// <returns></returns>
-        public TDerived TypeUnions(params string[] typeUnions)
-        {
-            AddActiveMemberAttribute(new TsTypeUnionsAttribute(typeUnions));
-            return this as TDerived;
-        }
-        
-        /// <summary>
-        /// Marks selected member as undefined (equivalent of TsUndefinedAttribute)
-        /// </summary>
-        /// <returns></returns>
-        public TDerived Undefined()
-        {
-            AddActiveMemberAttribute(new TsUndefinedAttribute());
-            return this as TDerived;
-        }
     }
 }

--- a/src/TypeGen/TypeGen.Core/SpecGeneration/GenerationSpec.cs
+++ b/src/TypeGen/TypeGen.Core/SpecGeneration/GenerationSpec.cs
@@ -53,6 +53,30 @@ namespace TypeGen.Core.SpecGeneration
         }
         
         /// <summary>
+        /// Adds a struct
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="outputDir"></param>
+        /// <returns></returns>
+        protected StructSpecBuilder AddStruct(Type type, string outputDir = null)
+        {
+            TypeSpec typeSpec = AddTypeSpec(type, new ExportTsStructAttribute { OutputDir = outputDir });
+            return new StructSpecBuilder(typeSpec);
+        }
+        
+        /// <summary>
+        /// Adds a struct
+        /// </summary>
+        /// <param name="outputDir"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        protected Generic.StructSpecBuilder<T> AddStruct<T>(string outputDir = null) where T : struct
+        {
+            TypeSpec typeSpec = AddTypeSpec(typeof(T), new ExportTsStructAttribute { OutputDir = outputDir });
+            return new Generic.StructSpecBuilder<T>(typeSpec);
+        }
+        
+        /// <summary>
         /// Adds an interface
         /// </summary>
         /// <param name="type"></param>

--- a/src/TypeGen/TypeGen.Core/SpecGeneration/Generic/StructSpecBuilder.cs
+++ b/src/TypeGen/TypeGen.Core/SpecGeneration/Generic/StructSpecBuilder.cs
@@ -1,0 +1,40 @@
+using System;
+using TypeGen.Core.TypeAnnotations;
+
+namespace TypeGen.Core.SpecGeneration.Generic
+{
+
+    /// <summary>
+    /// Builds the struct configuration section inside generation spec
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class StructSpecBuilder<T> : ClassOrInterfaceOrStructSpecBuilder<T, StructSpecBuilder<T>>
+    {
+        internal StructSpecBuilder(TypeSpec spec) : base(spec) { }
+
+        public StructSpecBuilder<T> Member(Func<T, string> memberNameFunc)
+        {
+            return Member(memberNameFunc(_instance));
+        }
+
+        /// <summary>
+        /// Marks selected member as static (equivalent of TsStaticAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public StructSpecBuilder<T> Static()
+        {
+            AddActiveMemberAttribute(new TsStaticAttribute());
+            return this;
+        }
+
+        /// <summary>
+        /// Marks selected member as not static (equivalent of TsNotStaticAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public StructSpecBuilder<T> NotStatic()
+        {
+            AddActiveMemberAttribute(new TsNotStaticAttribute());
+            return this;
+        }
+    }
+}

--- a/src/TypeGen/TypeGen.Core/SpecGeneration/StructSpecBuilder.cs
+++ b/src/TypeGen/TypeGen.Core/SpecGeneration/StructSpecBuilder.cs
@@ -1,0 +1,34 @@
+using TypeGen.Core.TypeAnnotations;
+
+namespace TypeGen.Core.SpecGeneration
+{
+
+    /// <summary>
+    /// Builds the struct configuration section inside generation spec
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class StructSpecBuilder : ClassOrInterfaceOrStructSpecBuilder<dynamic, StructSpecBuilder>
+    {
+        internal StructSpecBuilder(TypeSpec spec) : base(spec) { }
+
+        /// <summary>
+        /// Marks selected member as static (equivalent of TsStaticAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public StructSpecBuilder Static()
+        {
+            AddActiveMemberAttribute(new TsStaticAttribute());
+            return this;
+        }
+
+        /// <summary>
+        /// Marks selected member as not static (equivalent of TsNotStaticAttribute)
+        /// </summary>
+        /// <returns></returns>
+        public StructSpecBuilder NotStatic()
+        {
+            AddActiveMemberAttribute(new TsNotStaticAttribute());
+            return this;
+        }
+    }
+}

--- a/src/TypeGen/TypeGen.Core/TypeAnnotations/ExportTsStructAttribute.cs
+++ b/src/TypeGen/TypeGen.Core/TypeAnnotations/ExportTsStructAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace TypeGen.Core.TypeAnnotations
+{
+    /// <summary>
+    /// Identifies a class that a TypeScript file should be generated for
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Struct)]
+    public class ExportTsStructAttribute : ExportAttribute
+    {
+    }
+}

--- a/src/TypeGen/TypeGen.Core/TypeAnnotations/TsDefaultExportAttribute.cs
+++ b/src/TypeGen/TypeGen.Core/TypeAnnotations/TsDefaultExportAttribute.cs
@@ -5,7 +5,7 @@ namespace TypeGen.Core.TypeAnnotations
     /// <summary>
     /// Specifies that default export will be used for a TypeScript type
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Struct, Inherited = false)]
     public class TsDefaultExportAttribute : Attribute
     {
         public bool Enabled { get; set; }

--- a/src/TypeGen/TypeGen.IntegrationTest/Generator/Expected/point.ts
+++ b/src/TypeGen/TypeGen.IntegrationTest/Generator/Expected/point.ts
@@ -1,0 +1,9 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export class Point {
+    x: number = 0;
+    y: number = 0;
+}

--- a/src/TypeGen/TypeGen.IntegrationTest/Generator/Expected/point3.ts
+++ b/src/TypeGen/TypeGen.IntegrationTest/Generator/Expected/point3.ts
@@ -1,0 +1,10 @@
+/**
+ * This is a TypeGen auto-generated file.
+ * Any changes made to this file can be lost when this file is regenerated.
+ */
+
+export class Point3 {
+    x: number;
+    y: number;
+    z: number;
+}

--- a/src/TypeGen/TypeGen.IntegrationTest/Generator/GeneratorTest.cs
+++ b/src/TypeGen/TypeGen.IntegrationTest/Generator/GeneratorTest.cs
@@ -20,6 +20,27 @@ namespace TypeGen.IntegrationTest.Generator
         /// <param name="expectedLocation"></param>
         /// <returns></returns>
         [Theory]
+        [InlineData(typeof(TestEntities.Point), "TypeGen.IntegrationTest.Generator.Expected.point.ts")]
+        public async Task TestGenerate2(Type type, string expectedLocation)
+        {
+            var readExpectedTask = EmbededResourceReader.GetEmbeddedResourceAsync(expectedLocation);
+
+            var generator = new Gen.Generator();
+            var interceptor = GeneratorOutputInterceptor.CreateInterceptor(generator);
+
+            await generator.GenerateAsync(type.Assembly);
+            var expected = (await readExpectedTask).Trim();
+
+            Assert.True(interceptor.GeneratedOutputs.ContainsKey(type));
+            Assert.Equal(expected, FormatOutput(interceptor.GeneratedOutputs[type].Content));
+        }
+        /// <summary>
+        /// Tests if a variety of different classes are correctly translated to typescript
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="expectedLocation"></param>
+        /// <returns></returns>
+        [Theory]
         [InlineData(typeof(Constants.FooConstants), "TypeGen.IntegrationTest.Generator.Expected.foo-constants.ts")]
         [InlineData(typeof(TestEntities.CustomBaseCustomImport), "TypeGen.IntegrationTest.Generator.Expected.custom-base-custom-import.ts")]
         [InlineData(typeof(ErrorCase.Bar), "TypeGen.IntegrationTest.Generator.Expected.bar.ts")]
@@ -27,6 +48,8 @@ namespace TypeGen.IntegrationTest.Generator
         [InlineData(typeof(TestEntities.BaseClass2<>), "TypeGen.IntegrationTest.Generator.Expected.base-class2.ts")]
         [InlineData(typeof(ErrorCase.C), "TypeGen.IntegrationTest.Generator.Expected.c.ts")]
         [InlineData(typeof(TestEntities.CustomBaseClass), "TypeGen.IntegrationTest.Generator.Expected.custom-base-class.ts")]
+        [InlineData(typeof(TestEntities.Point), "TypeGen.IntegrationTest.Generator.Expected.point.ts")]
+        [InlineData(typeof(TestEntities.Point3), "TypeGen.IntegrationTest.Generator.Expected.point3.ts")]
         [InlineData(typeof(TestEntities.CustomEmptyBaseClass), "TypeGen.IntegrationTest.Generator.Expected.custom-empty-base-class.ts")]
         [InlineData(typeof(ErrorCase.D), "TypeGen.IntegrationTest.Generator.Expected.d.ts")]
         [InlineData(typeof(TestEntities.DefaultMemberValues), "TypeGen.IntegrationTest.Generator.Expected.default-member-values.ts")]
@@ -111,7 +134,11 @@ namespace TypeGen.IntegrationTest.Generator
         {
             public TestGenerationSpec()
             {
-
+                AddStruct<TestEntities.Point>()
+                    .Member(nameof(TestEntities.Point.X)).DefaultValue("0")
+                    .Member(nameof(TestEntities.Point.Y)).DefaultValue("0");
+                
+                AddStruct(typeof(TestEntities.Point3));
                 AddClass<TestEntities.CustomBaseClass>().CustomBase("AcmeCustomBase<string>");
                 AddInterface<TestEntities.CustomBaseCustomImport>().CustomBase("MB", "./my/base/my-base", "MyBase");
                 AddInterface<TestEntities.CustomEmptyBaseClass>().CustomBase();

--- a/src/TypeGen/TypeGen.IntegrationTest/TypeGen.IntegrationTest.csproj
+++ b/src/TypeGen/TypeGen.IntegrationTest/TypeGen.IntegrationTest.csproj
@@ -62,6 +62,8 @@
 		<EmbeddedResource Include="Generator\Expected\static-readonly.ts" />
 		<EmbeddedResource Include="Generator\Expected\enum-short-values.ts" />
 		<EmbeddedResource Include="Issues\CircularGenericConstraint\Expected\IRecursiveConstraintInterfaceWithStructConstraint.ts" />
+		<EmbeddedResource Include="Generator\Expected\point.ts" />
+		<EmbeddedResource Include="Generator\Expected\point3.ts" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TypeGen/TypeGen.TestWebApp/TestEntities/Point.cs
+++ b/src/TypeGen/TypeGen.TestWebApp/TestEntities/Point.cs
@@ -1,0 +1,11 @@
+using TypeGen.Core.TypeAnnotations;
+
+namespace TypeGen.TestWebApp.TestEntities
+{
+    [ExportTsStruct]
+    public struct Point
+    {
+        [TsDefaultValue("0")] public int X;
+        [TsDefaultValue("0")] public int Y;
+    }
+}

--- a/src/TypeGen/TypeGen.TestWebApp/TestEntities/Point3.cs
+++ b/src/TypeGen/TypeGen.TestWebApp/TestEntities/Point3.cs
@@ -1,0 +1,12 @@
+using TypeGen.Core.TypeAnnotations;
+
+namespace TypeGen.TestWebApp.TestEntities
+{
+    [ExportTsStruct]
+    public struct Point3
+    {
+        public int X;
+        public int Y;
+        public int Z;
+    }
+}


### PR DESCRIPTION
I tried to orient myself with the help of #90.

I hope my changes are close to idiomatic. The tests are mostly copy pasted from the class generation tests, but that seems to be the way to go here?!

`GenerateStruct` is the place that needs the most scrutiny. I pretty much just reused the class function again. Some names might not be totally correct. If that is an issue I'll try to update them. Thing is this PR is already pretty big and I would prefer not blowing it up even further.