### PR TITLE
Added support to Export Enums as UnionTypes, Added support to set Output path with Cli parameter

### DIFF
--- a/src/TypeGen/TypeGen.Cli.Test/Business/ConsoleArgsReaderTest.cs
+++ b/src/TypeGen/TypeGen.Cli.Test/Business/ConsoleArgsReaderTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using TypeGen.Cli.Business;
 using Xunit;
 
@@ -110,7 +111,28 @@ namespace TypeGen.Cli.Test.Business
             new object[] { new[] { "asdf", "d" }, false },
             new object[] { new string[] {}, false }
         };
-        
+
+        [Theory]
+        [MemberData(nameof(ContainsOutputFolderOption_TestData))]
+        public void ContainsOutputFolderOption_Test(string[] args, bool expectedResult)
+        {
+            bool actualResult = _consoleArgsReader.ContainsOutputOption(args);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        public static IEnumerable<object[]> ContainsOutputFolderOption_TestData = new[]
+        {
+            new object[] { new[] { "asdf", "-o", "d" }, true },
+            new object[] { new[] { "asdf", "--output-folder", "d" }, true },
+            new object[] { new[] { "asdf", "-O", "d" }, true },
+            new object[] { new[] { "asdf", "--OUTPUT-FOLDER", "d" }, true },
+            new object[] { new[] { "asdf", "--OuTpUt-FoldER", "d" }, true },
+            new object[] { new[] { "-o" }, true },
+            new object[] { new[] { "--output-folder" }, true },
+            new object[] { new[] { "asdf", "d" }, false },
+            new object[] { new string[] {}, false }
+        };
+
         [Theory]
         [MemberData(nameof(ContainsVerboseOption_TestData))]
         public void ContainsVerboseOption_Test(string[] args, bool expectedResult)
@@ -155,6 +177,31 @@ namespace TypeGen.Cli.Test.Business
         {
             var args = new[] { "--project-folder" };
             Assert.Throws<CliException>(() => _consoleArgsReader.GetProjectFolders(args));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetOutputFolder_TestData))]
+        public void GetOutputFolder_Test(string[] args, string expectedResult)
+        {
+            string actualResult = _consoleArgsReader.GetOutputFolder(args);
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        public static IEnumerable<object[]> GetOutputFolder_TestData = new[]
+        {
+            new object[] { new[] { "-o", "asdf", "project/folder" },  "asdf" },
+            new object[] { new[] { "--output-folder", "asdf", @"C:\project\folder" }, "asdf" },
+            new object[] { new[] { "-o", "asdf|qwer", "--config-path", "zxcv" }, "asdf" },
+            new object[] { new[] { "--output-folder", @"D:\my\folder|some/other/folder|that/folder", "--config-path", "zxcv|qwer" }, @"D:\my\folder" },
+            new object[] { new[] { "asdf" }, null },
+            new object[] { new string[] {}, null }
+        };
+
+        [Fact]
+        public void GetOutputFolder_ParameterPresentAndNoPathsSpecified_ExceptionThrown()
+        {
+            var args = new[] { "--output-folder" };
+            Assert.Throws<CliException>(() => _consoleArgsReader.GetOutputFolder(args));
         }
 
         [Theory]

--- a/src/TypeGen/TypeGen.Cli/Business/ConsoleArgsReader.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/ConsoleArgsReader.cs
@@ -24,10 +24,12 @@ namespace TypeGen.Cli.Business
 
         public bool ContainsHelpOption(string[] args) => ContainsOption(args, "-h", "--help");
         public bool ContainsProjectFolderOption(string[] args) => ContainsOption(args, "-p", "--project-folder");
+        public bool ContainsOutputOption(string[] args) => ContainsOption(args, "-o", "--output-folder");
         public bool ContainsVerboseOption(string[] args) => ContainsOption(args, "-v", "--verbose");
         private bool ContainsOption(string[] args, string optionShortName, string optionFullName) => args.Any(arg => string.Equals(arg, optionShortName, StringComparison.InvariantCultureIgnoreCase) || string.Equals(arg, optionFullName, StringComparison.InvariantCultureIgnoreCase));
 
         public IEnumerable<string> GetProjectFolders(string[] args) => GetPathsParam(args, "-p", "--project-folder");
+        public string GetOutputFolder(string[] args) => GetPathsParam(args, "-o", "--output-folder").FirstOrDefault();
         public IEnumerable<string> GetConfigPaths(string[] args) => GetPathsParam(args, "-c", "--config-path");
 
         private IEnumerable<string> GetPathsParam(string[] args, string paramShortName, string paramFullName)

--- a/src/TypeGen/TypeGen.Cli/Business/IConsoleArgsReader.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/IConsoleArgsReader.cs
@@ -9,8 +9,10 @@ namespace TypeGen.Cli.Business
         bool ContainsAnyCommand(string[] args);
         bool ContainsHelpOption(string[] args);
         bool ContainsProjectFolderOption(string[] args);
+        bool ContainsOutputOption(string[] args);
         bool ContainsVerboseOption(string[] args);
         IEnumerable<string> GetProjectFolders(string[] args);
+        string GetOutputFolder(string[] args);
         IEnumerable<string> GetConfigPaths(string[] args);
     }
 }

--- a/src/TypeGen/TypeGen.Cli/Program.cs
+++ b/src/TypeGen/TypeGen.Cli/Program.cs
@@ -67,6 +67,9 @@ namespace TypeGen.Cli
                     _consoleArgsReader.GetProjectFolders(args).ToArray() :
                     new [] { "." };
 
+                string? outputFolder = _consoleArgsReader.ContainsOutputOption(args) ?
+                    _consoleArgsReader.GetOutputFolder(args) : null;
+
                 for (var i = 0; i < projectFolders.Length; i++)
                 {
                     string projectFolder = projectFolders[i];
@@ -74,7 +77,7 @@ namespace TypeGen.Cli
 
                     _assemblyResolver = new AssemblyResolver(_fileSystem, _logger, projectFolder);
 
-                    Generate(projectFolder, configPath);
+                    Generate(projectFolder, configPath, outputFolder);
                 }
                 
                 return (int)ExitCode.Success;
@@ -107,7 +110,7 @@ namespace TypeGen.Cli
             }
         }
 
-        private static void Generate(string projectFolder, string configPath)
+        private static void Generate(string projectFolder, string configPath, string? outputFolder)
         {
             // get config
 
@@ -127,7 +130,7 @@ namespace TypeGen.Cli
             // create generator
 
             GeneratorOptions generatorOptions = _generatorOptionsProvider.GetGeneratorOptions(config, assemblies, projectFolder);
-            generatorOptions.BaseOutputDirectory = Path.Combine(projectFolder, config.OutputPath);
+            generatorOptions.BaseOutputDirectory = outputFolder ?? Path.Combine(projectFolder, config.OutputPath);
             var generator = new Generator(generatorOptions, _logger);
 
             // generate

--- a/src/TypeGen/TypeGen.Core/Generator/Generator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Generator.cs
@@ -649,6 +649,7 @@ namespace TypeGen.Core.Generator
         /// Gets TypeScript enum member definition source code
         /// </summary>
         /// <param name="fieldInfo">MemberInfo for an enum value</param>
+        /// <param name="asUnionType">defines if generated Text should ab applicable for union types</param>
         /// <returns></returns>
         private string GetEnumMemberText(FieldInfo fieldInfo, bool asUnionType)
         {
@@ -673,6 +674,7 @@ namespace TypeGen.Core.Generator
         /// Gets TypeScript enum member definition source code
         /// </summary>
         /// <param name="type"></param>
+        /// <param name="asUnionType"></param>
         /// <returns></returns>
         private string GetEnumMembersText(Type type, bool asUnionType)
         {

--- a/src/TypeGen/TypeGen.Core/Generator/Generator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Generator.cs
@@ -582,7 +582,7 @@ namespace TypeGen.Core.Generator
             propertiesText += memberInfos
                 .Aggregate(propertiesText, (current, memberInfo) => current + GetClassPropertyText(memberInfo));
 
-            return RemoveLastLineEnding(propertiesText, false);
+            return RemoveLastLineEnding(propertiesText);
         }
 
         /// <summary>
@@ -642,7 +642,7 @@ namespace TypeGen.Core.Generator
             propertiesText += memberInfos
                 .Aggregate(propertiesText, (current, memberInfo) => current + GetInterfacePropertyText(memberInfo));
 
-            return RemoveLastLineEnding(propertiesText, false);
+            return RemoveLastLineEnding(propertiesText);
         }
 
         /// <summary>
@@ -683,7 +683,7 @@ namespace TypeGen.Core.Generator
 
             valuesText += fieldInfos.Aggregate(valuesText, (current, fieldInfo) => current + GetEnumMemberText(fieldInfo, asUnionType));
 
-            return RemoveLastLineEnding(valuesText, asUnionType);
+            return asUnionType ? TrimForEnumUnionTypeValues(valuesText) : RemoveLastLineEnding(valuesText);
         }
 
         /// <summary>
@@ -792,10 +792,14 @@ namespace TypeGen.Core.Generator
             }
         }
 
-        private static string RemoveLastLineEnding(string propertiesText, bool asUnionType)
+        private static string RemoveLastLineEnding(string propertiesText)
         {
-            var trimmed = propertiesText.Trim().TrimEnd('\r', '\n');
-            return asUnionType ? trimmed.TrimEnd('|') : trimmed;
+            return propertiesText.TrimEnd('\r', '\n');
+        }
+
+        private static string TrimForEnumUnionTypeValues(string propertiesText)
+        {
+            return RemoveLastLineEnding(propertiesText).Trim().TrimEnd('|');
         }
     }
 }

--- a/src/TypeGen/TypeGen.Core/Generator/Services/ITemplateService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/ITemplateService.cs
@@ -10,9 +10,10 @@ namespace TypeGen.Core.Generator.Services
         string FillInterfaceTemplate(string imports, string name, string extends, string properties, string customHead, string customBody, string fileHeading = null);
         string FillInterfaceDefaultExportTemplate(string imports, string name, string exportName, string extends, string properties, string customHead, string customBody, string fileHeading = null);
         string FillInterfacePropertyTemplate(string modifiers, string name, string type, IEnumerable<string> typeUnions, bool isOptional);
-        string FillEnumTemplate(string imports, string name, string values, bool isConst, string customHead, string customBody, string fileHeading = null);
-        string FillEnumDefaultExportTemplate(string imports, string name, string values, bool isConst, string fileHeading = null);
+        string FillEnumTemplate(string imports, string name, string values, bool isConst, bool asUnionType, string customHead, string customBody, string fileHeading = null);
+        string FillEnumDefaultExportTemplate(string imports, string name, string values, bool isConst, bool asUnionType, string fileHeading = null);
         string FillEnumValueTemplate(string name, object value);
+        string FillEnumUnionTypeValueTemplate(string name);
         string FillImportTemplate(string name, string typeAlias, string path);
         string FillImportDefaultExportTemplate(string name, string path);
         string FillIndexTemplate(string exports);

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TemplateService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TemplateService.cs
@@ -17,8 +17,11 @@ namespace TypeGen.Core.Generator.Services
         private readonly IGeneratorOptionsProvider _generatorOptionsProvider;
 
         private readonly string _enumTemplate;
+        private readonly string _enumUnionTypeTemplate;
         private readonly string _enumDefaultExportTemplate;
+        private readonly string _enumUnionTypeDefaultExportTemplate;
         private readonly string _enumValueTemplate;
+        private readonly string _enumUnionTypeValueTemplate;
         private readonly string _classTemplate;
         private readonly string _classDefaultExportTemplate;
         private readonly string _classPropertyTemplate;
@@ -39,8 +42,11 @@ namespace TypeGen.Core.Generator.Services
             _generatorOptionsProvider = generatorOptionsProvider;
 
             _enumTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.Enum.tpl");
+            _enumUnionTypeTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.EnumUnionType.tpl");
             _enumDefaultExportTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.EnumDefaultExport.tpl");
+            _enumUnionTypeDefaultExportTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.EnumUnionTypeDefaultExport.tpl");
             _enumValueTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.EnumValue.tpl");
+            _enumUnionTypeValueTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.EnumUnionTypeValue.tpl");
             _classTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.Class.tpl");
             _classDefaultExportTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.ClassDefaultExport.tpl");
             _classPropertyTemplate = _internalStorage.GetEmbeddedResource("TypeGen.Core.Templates.ClassProperty.tpl");
@@ -139,11 +145,11 @@ namespace TypeGen.Core.Generator.Services
                 .Replace(GetTag("type"), type);
         }
 
-        public string FillEnumTemplate(string imports, string name, string values, bool isConst, string customHead, string customBody, string fileHeading = null)
+        public string FillEnumTemplate(string imports, string name, string values, bool isConst, bool asUnionType, string customHead, string customBody, string fileHeading = null)
         {
             if (fileHeading == null) fileHeading = _headingTemplate;
             
-            return ReplaceSpecialChars(_enumTemplate)
+            return ReplaceSpecialChars(asUnionType ? _enumUnionTypeTemplate : _enumTemplate)
                 .Replace(GetTag("imports"), imports)
                 .Replace(GetTag("name"), name)
                 .Replace(GetTag("values"), values)
@@ -153,11 +159,11 @@ namespace TypeGen.Core.Generator.Services
                 .Replace(GetTag("fileHeading"), fileHeading);
         }
         
-        public string FillEnumDefaultExportTemplate(string imports, string name, string values, bool isConst, string fileHeading = null)
+        public string FillEnumDefaultExportTemplate(string imports, string name, string values, bool isConst, bool asUnionType, string fileHeading = null)
         {
             if (fileHeading == null) fileHeading = _headingTemplate;
             
-            return ReplaceSpecialChars(_enumDefaultExportTemplate)
+            return ReplaceSpecialChars(asUnionType ? _enumUnionTypeDefaultExportTemplate : _enumDefaultExportTemplate)
                 .Replace(GetTag("imports"), imports)
                 .Replace(GetTag("name"), name)
                 .Replace(GetTag("values"), values)
@@ -173,6 +179,14 @@ namespace TypeGen.Core.Generator.Services
             return ReplaceSpecialChars(_enumValueTemplate)
                 .Replace(GetTag("name"), name)
                 .Replace(GetTag("value"), valueString);
+        }
+
+        public string FillEnumUnionTypeValueTemplate(string name)
+        {
+            char quote = GeneratorOptions.SingleQuotes ? '\'' : '"';
+
+            return ReplaceSpecialChars(_enumUnionTypeValueTemplate)
+                .Replace(GetTag("name"), $@"{quote}{name}{quote}");
         }
 
         public string FillImportTemplate(string name, string typeAlias, string path)

--- a/src/TypeGen/TypeGen.Core/Templates/EnumUnionType.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/EnumUnionType.tpl
@@ -1,0 +1,1 @@
+$tg{fileHeading}$tg{customHead}export$tg{modifiers} type $tg{name} = $tg{values}$tg{customBody}

--- a/src/TypeGen/TypeGen.Core/Templates/EnumUnionTypeDefaultExport.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/EnumUnionTypeDefaultExport.tpl
@@ -1,0 +1,2 @@
+$tg{fileHeading}$tg{modifiers} type $tg{name} = $tg{values}
+export default $tg{name};

--- a/src/TypeGen/TypeGen.Core/Templates/EnumUnionTypeValue.tpl
+++ b/src/TypeGen/TypeGen.Core/Templates/EnumUnionTypeValue.tpl
@@ -1,0 +1,1 @@
+$tg{tab}$tg{name}|

--- a/src/TypeGen/TypeGen.Core/TypeAnnotations/ExportTsEnumAttribute.cs
+++ b/src/TypeGen/TypeGen.Core/TypeAnnotations/ExportTsEnumAttribute.cs
@@ -12,5 +12,6 @@ namespace TypeGen.Core.TypeAnnotations
         /// Specifies whether an enum should be exported as TypeScript const enum
         /// </summary>
         public bool IsConst { get; set; }
+        public bool AsUnionType { get; set; }
     }
 }

--- a/src/TypeGen/TypeGen.Core/TypeAnnotations/ExportTsEnumAttribute.cs
+++ b/src/TypeGen/TypeGen.Core/TypeAnnotations/ExportTsEnumAttribute.cs
@@ -12,6 +12,9 @@ namespace TypeGen.Core.TypeAnnotations
         /// Specifies whether an enum should be exported as TypeScript const enum
         /// </summary>
         public bool IsConst { get; set; }
+        /// <summary>
+        /// Specifies whether the enum should be exported as a TypeScript UnionType
+        /// </summary>
         public bool AsUnionType { get; set; }
     }
 }

--- a/src/TypeGen/TypeGen.Core/TypeGen.Core.csproj
+++ b/src/TypeGen/TypeGen.Core/TypeGen.Core.csproj
@@ -10,6 +10,9 @@
     <None Remove="Templates\ClassPropertyWithDefaultValue.tpl" />
     <None Remove="Templates\Constant.tpl" />
     <None Remove="Templates\Enum.tpl" />
+    <None Remove="Templates\EnumUnionType.tpl" />
+    <None Remove="Templates\EnumUnionTypeDefaultExport.tpl" />
+    <None Remove="Templates\EnumUnionTypeValue.tpl" />
     <None Remove="Templates\EnumValue.tpl" />
     <None Remove="Templates\Import.tpl" />
     <None Remove="Templates\Interface.tpl" />
@@ -21,8 +24,11 @@
     <EmbeddedResource Include="Templates\Class.tpl" />
     <EmbeddedResource Include="Templates\ClassDefaultExport.tpl" />
     <EmbeddedResource Include="Templates\ClassProperty.tpl" />
+    <EmbeddedResource Include="Templates\EnumUnionTypeDefaultExport.tpl" />
+    <EmbeddedResource Include="Templates\EnumUnionType.tpl" />
     <EmbeddedResource Include="Templates\Enum.tpl" />
     <EmbeddedResource Include="Templates\EnumDefaultExport.tpl" />
+    <EmbeddedResource Include="Templates\EnumUnionTypeValue.tpl" />
     <EmbeddedResource Include="Templates\EnumValue.tpl" />
     <EmbeddedResource Include="Templates\Heading.tpl" />
     <EmbeddedResource Include="Templates\Import.tpl" />


### PR DESCRIPTION
# 2 new features in this PR

## Feature 1: Enum UnionTypes
I had a need to export Enums as (Union-)Types.
So for the following Enum:

```c#
public enum SocialMediaTypes 
{
    Facebook,
    Twitter,
    Instagram,
    Mastodon
}
```

I needed a typescript type to be generated:

```ts
export type SocialMediaTypes = "Facebook" | "Twitter" | "Instagram" | "Mastodon"
```

this PR adds an option to the ExportEnumAttribute to define it as UnionType

```c#
[AttributeUsage(AttributeTargets.Enum)]
public class ExportTsEnumAttribute : ExportAttribute
{
    /// <summary>
    /// Specifies whether an enum should be exported as TypeScript const enum
    /// </summary>
    public bool IsConst { get; set; }
    /// <summary>
    /// Specifies whether the enum should be exported as a TypeScript UnionType
    /// </summary>
    public bool AsUnionType { get; set; }
}
```

## Feature 2: define output path on cli
I am not working with a config file, because i don't have a need for one. The only thing that I needed, that wasn't available on the cli is the option to define an output path when generating using the cli. I need this for my build pipelines, where I generate npm packages during build and deployment.

for this a new commandline option was added `-o` or `--output-path`. this will be preferred, over the output path in the config, if set.

