### PR TITLE
Better support for Record Classes and Base Class for TsExportInterface

### DIFF
--- a/src/TypeGen/TypeGen.Cli/Business/ConsoleArgsReader.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/ConsoleArgsReader.cs
@@ -25,12 +25,14 @@ namespace TypeGen.Cli.Business
         public static bool ContainsHelpOption(string[] args) => ContainsOption(args, "-h", "--help");
         public static bool ContainsProjectFolderOption(string[] args) => ContainsOption(args, "-p", "--project-folder");
         public static bool ContainsOutputOption(string[] args) => ContainsOption(args, "-o", "--output-folder");
+        public static bool ContainsRecordClassOption(string[] args) => ContainsOption(args, "-er", "--exclude-record-class");
         public static bool ContainsVerboseOption(string[] args) => ContainsOption(args, "-v", "--verbose");
         private static bool ContainsOption(string[] args, string optionShortName, string optionFullName) => args.Any(arg => string.Equals(arg, optionShortName, StringComparison.InvariantCultureIgnoreCase) || string.Equals(arg, optionFullName, StringComparison.InvariantCultureIgnoreCase));
 
         public static IEnumerable<string> GetProjectFolders(string[] args) => GetPathsParam(args, "-p", "--project-folder");
         public static string GetOutputFolder(string[] args) => GetPathsParam(args, "-o", "--output-folder").FirstOrDefault();
         public static IEnumerable<string> GetConfigPaths(string[] args) => GetPathsParam(args, "-c", "--config-path");
+        public static bool? GetRecordClassOption(string[] args) => GetFlagParam(args, "-er", "--exclude-record-class");
 
         private static IEnumerable<string> GetPathsParam(string[] args, string paramShortName, string paramFullName)
         {
@@ -50,6 +52,34 @@ namespace TypeGen.Cli.Business
 
             if (args.Length < index + 2) throw new CliException($"{paramShortName}|{paramFullName} parameter present, but no path specified");
             return args[index + 1].Split(PathSeparator);
+        }
+
+        private static bool? GetFlagParam(string[] args, string paramShortName, string paramFullName)
+        {
+            int index = -1;
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (args[i].Equals(paramShortName, StringComparison.InvariantCultureIgnoreCase) ||
+                    args[i].Equals(paramFullName, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index < 0) return null;
+
+            if(args.Length == index + 1 || args[index + 1].StartsWith("-"))
+            {
+                return true;
+            }
+
+            if(bool.TryParse(args[index+1], out var flag))
+            {
+                return flag;
+            }
+            return null;
         }
     }
 }

--- a/src/TypeGen/TypeGen.Cli/Business/ConsoleArgsReader.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/ConsoleArgsReader.cs
@@ -26,6 +26,7 @@ namespace TypeGen.Cli.Business
         public static bool ContainsProjectFolderOption(string[] args) => ContainsOption(args, "-p", "--project-folder");
         public static bool ContainsOutputOption(string[] args) => ContainsOption(args, "-o", "--output-folder");
         public static bool ContainsRecordClassOption(string[] args) => ContainsOption(args, "-er", "--exclude-record-class");
+        public static bool ContainsIncludeBaseClassForInterfacesOption(string[] args) => ContainsOption(args, "-ib", "--include-base-for-interfaces");
         public static bool ContainsVerboseOption(string[] args) => ContainsOption(args, "-v", "--verbose");
         private static bool ContainsOption(string[] args, string optionShortName, string optionFullName) => args.Any(arg => string.Equals(arg, optionShortName, StringComparison.InvariantCultureIgnoreCase) || string.Equals(arg, optionFullName, StringComparison.InvariantCultureIgnoreCase));
 
@@ -33,6 +34,7 @@ namespace TypeGen.Cli.Business
         public static string GetOutputFolder(string[] args) => GetPathsParam(args, "-o", "--output-folder").FirstOrDefault();
         public static IEnumerable<string> GetConfigPaths(string[] args) => GetPathsParam(args, "-c", "--config-path");
         public static bool? GetRecordClassOption(string[] args) => GetFlagParam(args, "-er", "--exclude-record-class");
+        public static bool? GetIncludeBaseClassForInterfacesOption(string[] args) => GetFlagParam(args, "-ib", "--include-base-for-interfaces");
 
         private static IEnumerable<string> GetPathsParam(string[] args, string paramShortName, string paramFullName)
         {

--- a/src/TypeGen/TypeGen.Cli/Business/GeneratorOptionsProvider.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/GeneratorOptionsProvider.cs
@@ -62,6 +62,7 @@ namespace TypeGen.Cli.Business
                 CsAllowNullsForAllTypes = config.CsAllowNullsForAllTypes ?? GeneratorOptions.DefaultCsAllowNullsForAllTypes,
                 CsDefaultValuesForConstantsOnly = config.CsDefaultValuesForConstantsOnly ?? GeneratorOptions.DefaultCsDefaultValuesForConstantsOnly,
                 CreateIndexFile = config.CreateIndexFile ?? GeneratorOptions.DefaultCreateIndexFile,
+                ExcludeIEquatableForRecordClass = config.ExcludeIEquatableForRecordClass ?? GeneratorOptions.DefaultExcludeIEquatableForRecordClass,
                 DefaultValuesForTypes = config.DefaultValuesForTypes ?? GeneratorOptions.DefaultDefaultValuesForTypes,
                 TypeUnionsForTypes = config.TypeUnionsForTypes ?? GeneratorOptions.DefaultTypeUnionsForTypes,
                 CustomTypeMappings = config.CustomTypeMappings ?? GeneratorOptions.DefaultCustomTypeMappings,

--- a/src/TypeGen/TypeGen.Cli/Business/GeneratorOptionsProvider.cs
+++ b/src/TypeGen/TypeGen.Cli/Business/GeneratorOptionsProvider.cs
@@ -62,6 +62,7 @@ namespace TypeGen.Cli.Business
                 CsAllowNullsForAllTypes = config.CsAllowNullsForAllTypes ?? GeneratorOptions.DefaultCsAllowNullsForAllTypes,
                 CsDefaultValuesForConstantsOnly = config.CsDefaultValuesForConstantsOnly ?? GeneratorOptions.DefaultCsDefaultValuesForConstantsOnly,
                 CreateIndexFile = config.CreateIndexFile ?? GeneratorOptions.DefaultCreateIndexFile,
+                IncludeBaseClassWhenExportedAsInterface = config.IncludeBaseClassWhenExportedAsInterface ?? GeneratorOptions.DefaultIncludeBaseClassWhenExportedAsInterface,
                 ExcludeIEquatableForRecordClass = config.ExcludeIEquatableForRecordClass ?? GeneratorOptions.DefaultExcludeIEquatableForRecordClass,
                 DefaultValuesForTypes = config.DefaultValuesForTypes ?? GeneratorOptions.DefaultDefaultValuesForTypes,
                 TypeUnionsForTypes = config.TypeUnionsForTypes ?? GeneratorOptions.DefaultTypeUnionsForTypes,

--- a/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
+++ b/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
@@ -85,6 +85,8 @@ namespace TypeGen.Cli.Models
             if (EnumStringInitializersConverters == null) EnumStringInitializersConverters = GeneratorOptions.DefaultEnumStringInitializersConverters.GetTypeNames().ToArray();
             if (ExternalAssemblyPaths == null) ExternalAssemblyPaths = Array.Empty<string>();
             if (CreateIndexFile == null) CreateIndexFile = GeneratorOptions.DefaultCreateIndexFile;
+            if (IncludeBaseClassWhenExportedAsInterface == null) IncludeBaseClassWhenExportedAsInterface = GeneratorOptions.DefaultIncludeBaseClassWhenExportedAsInterface;
+            if (ExcludeIEquatableForRecordClass == null) ExcludeIEquatableForRecordClass = GeneratorOptions.DefaultExcludeIEquatableForRecordClass;
             if (CsNullableTranslation == null) CsNullableTranslation = GeneratorOptions.DefaultCsNullableTranslation.ToFlagString();
             if (CsAllowNullsForAllTypes == null) CsAllowNullsForAllTypes = GeneratorOptions.DefaultCsAllowNullsForAllTypes;
             if (CsDefaultValuesForConstantsOnly == null) CsDefaultValuesForConstantsOnly = GeneratorOptions.DefaultCsDefaultValuesForConstantsOnly;

--- a/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
+++ b/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
@@ -39,6 +39,7 @@ namespace TypeGen.Cli.Models
         public string OutputPath { get; set; }
         public bool? ClearOutputDirectory { get; set; }
         public bool? CreateIndexFile { get; set; }
+        public bool? IncludeBaseClassWhenExportedAsInterface { get; set; }
         public bool? ExcludeIEquatableForRecordClass { get; set; }
         public string CsNullableTranslation { get; set; }
         public bool? CsAllowNullsForAllTypes { get; set; }

--- a/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
+++ b/src/TypeGen/TypeGen.Cli/Models/TgConfig.cs
@@ -39,6 +39,7 @@ namespace TypeGen.Cli.Models
         public string OutputPath { get; set; }
         public bool? ClearOutputDirectory { get; set; }
         public bool? CreateIndexFile { get; set; }
+        public bool? ExcludeIEquatableForRecordClass { get; set; }
         public string CsNullableTranslation { get; set; }
         public bool? CsAllowNullsForAllTypes { get; set; }
         public bool? CsDefaultValuesForConstantsOnly { get; set; }

--- a/src/TypeGen/TypeGen.Cli/Program.cs
+++ b/src/TypeGen/TypeGen.Cli/Program.cs
@@ -67,6 +67,9 @@ namespace TypeGen.Cli
                 string? outputFolder = ConsoleArgsReader.ContainsOutputOption(args) ?
                     ConsoleArgsReader.GetOutputFolder(args) : null;
 
+                bool? excludeRecordClass = ConsoleArgsReader.ContainsRecordClassOption(args) ?
+                    ConsoleArgsReader.GetRecordClassOption(args) : null;
+
                 for (var i = 0; i < projectFolders.Length; i++)
                 {
                     string projectFolder = projectFolders[i];
@@ -74,7 +77,7 @@ namespace TypeGen.Cli
 
                     _assemblyResolver = new AssemblyResolver(_fileSystem, _logger, projectFolder);
 
-                    Generate(projectFolder, configPath, outputFolder);
+                    Generate(projectFolder, configPath, outputFolder, excludeRecordClass);
                 }
                 
                 return (int)ExitCode.Success;
@@ -102,7 +105,7 @@ namespace TypeGen.Cli
             }
         }
 
-        private static void Generate(string projectFolder, string configPath, string? outputFolder)
+        private static void Generate(string projectFolder, string configPath, string? outputFolder, bool? excludeRecordClass)
         {
             // get config
 
@@ -111,6 +114,11 @@ namespace TypeGen.Cli
                 : Path.Combine(projectFolder, "tgconfig.json");
 
             TgConfig config = _configProvider.GetConfig(configPath, projectFolder);
+
+            if(excludeRecordClass is not null)
+            {
+                config.ExcludeIEquatableForRecordClass = excludeRecordClass;
+            }
 
             // register assembly resolver
 

--- a/src/TypeGen/TypeGen.Core/Generator/GeneratorOptions.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/GeneratorOptions.cs
@@ -22,6 +22,7 @@ namespace TypeGen.Core.Generator
         public static bool DefaultSingleQuotes => false;
         public static bool DefaultCreateIndexFile => false;
         public static bool DefaultExcludeIEquatableForRecordClass => false;
+        public static bool DefaultIncludeBaseClassWhenExportedAsInterface => false;
         public static StrictNullTypeUnionFlags DefaultCsNullableTranslation => StrictNullTypeUnionFlags.None;
         public static bool DefaultCsAllowNullsForAllTypes = false;
         public static bool DefaultCsDefaultValuesForConstantsOnly = false;
@@ -106,6 +107,11 @@ namespace TypeGen.Core.Generator
         /// C# compiler adds IEquatable interface to all record types. To exclude those from export set this to true.
         /// </summary>
         public bool ExcludeIEquatableForRecordClass { get; set; } = DefaultExcludeIEquatableForRecordClass;
+
+        /// <summary>
+        /// When a class is exported as interface extend the interface with the baseclass, when present and is also exported as interface
+        /// </summary>
+        public bool IncludeBaseClassWhenExportedAsInterface { get; set; } = DefaultIncludeBaseClassWhenExportedAsInterface;
 
         /// <summary>
         /// Indicates which union types (null, undefined) are added to TypeScript property types for C# nullable types by default

--- a/src/TypeGen/TypeGen.Core/Generator/GeneratorOptions.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/GeneratorOptions.cs
@@ -21,6 +21,7 @@ namespace TypeGen.Core.Generator
         public static string DefaultTypeScriptFileExtension => "ts";
         public static bool DefaultSingleQuotes => false;
         public static bool DefaultCreateIndexFile => false;
+        public static bool DefaultExcludeIEquatableForRecordClass => false;
         public static StrictNullTypeUnionFlags DefaultCsNullableTranslation => StrictNullTypeUnionFlags.None;
         public static bool DefaultCsAllowNullsForAllTypes = false;
         public static bool DefaultCsDefaultValuesForConstantsOnly = false;
@@ -100,6 +101,11 @@ namespace TypeGen.Core.Generator
         /// Whether to create an index file which exports all generated types
         /// </summary>
         public bool CreateIndexFile { get; set; } = DefaultCreateIndexFile;
+
+        /// <summary>
+        /// C# compiler adds IEquatable interface to all record types. To exclude those from export set this to true.
+        /// </summary>
+        public bool ExcludeIEquatableForRecordClass { get; set; } = DefaultExcludeIEquatableForRecordClass;
 
         /// <summary>
         /// Indicates which union types (null, undefined) are added to TypeScript property types for C# nullable types by default

--- a/src/TypeGen/TypeGen.Core/Generator/Services/ITypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/ITypeService.cs
@@ -127,5 +127,6 @@ namespace TypeGen.Core.Generator.Services
 
         IEnumerable<string> GetTypeUnions(MemberInfo memberInfo);
         IEnumerable<Type> GetInterfaces(Type type);
+        bool IsRecordClass(Type type);
     }
 }

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TsContentGenerator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TsContentGenerator.cs
@@ -113,6 +113,12 @@ namespace TypeGen.Core.Generator.Services
             Requires.NotNull(GeneratorOptions.TypeNameConverters, nameof(GeneratorOptions.TypeNameConverters));
 
             IEnumerable<Type> baseTypes = _typeService.GetInterfaces(type);
+
+            if (baseTypes.Any() && _generatorOptionsProvider.GeneratorOptions.ExcludeIEquatableForRecordClass && _typeService.IsRecordClass(type))
+            {
+                baseTypes = baseTypes.Where(t => !t.IsGenericType || t.GetGenericTypeDefinition() != typeof(IEquatable<>));
+            }
+
             if (!baseTypes.Any()) return "";
 
             IEnumerable<string> baseTypeNames = baseTypes.Select(baseType => _typeService.GetTsTypeName(baseType, true));
@@ -130,6 +136,12 @@ namespace TypeGen.Core.Generator.Services
             Requires.NotNull(GeneratorOptions.TypeNameConverters, nameof(GeneratorOptions.TypeNameConverters));
 
             IEnumerable<Type> baseTypes = _typeService.GetInterfaces(type);
+                        
+            if (baseTypes.Any() && _generatorOptionsProvider.GeneratorOptions.ExcludeIEquatableForRecordClass && _typeService.IsRecordClass(type))
+            {
+                baseTypes = baseTypes.Where(t => !t.IsGenericType || t.GetGenericTypeDefinition() != typeof(IEquatable<>));
+            }
+
             if (!baseTypes.Any()) return "";
 
             IEnumerable<string> baseTypeNames = baseTypes.Select(baseType => _typeService.GetTsTypeName(baseType, true));

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeDependencyService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeDependencyService.cs
@@ -113,6 +113,12 @@ namespace TypeGen.Core.Generator.Services
             if (_metadataReaderFactory.GetInstance().GetAttribute<TsIgnoreBaseAttribute>(type) != null) return Enumerable.Empty<TypeDependencyInfo>();
 
             var baseTypes = _typeService.GetInterfaces(type);
+
+            if(baseTypes.Any() && _generatorOptionsProvider.GeneratorOptions.ExcludeIEquatableForRecordClass && _typeService.IsRecordClass(type))
+            {
+                baseTypes = baseTypes.Where(t => !t.IsGenericType || t.GetGenericTypeDefinition() != typeof(IEquatable<>));
+            }
+
             if (!baseTypes.Any()) return Enumerable.Empty<TypeDependencyInfo>();
 
             return baseTypes

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TypeService.cs
@@ -560,5 +560,7 @@ namespace TypeGen.Core.Generator.Services
 
             return baseTypes;
         }
+        public bool IsRecordClass(Type type)
+            => type.GetMethods().Any(m => m.Name == "<Clone>$");
     }
 }


### PR DESCRIPTION
this fixes #164 

When Record Class Types are used the c# compiler generates IEquatable for those classes. When exported as Interface or Classes, those will be generated too. I added a flag in the options to exclude those. I also added a cli flag to activate this option.

In #104 there is this point:
- If the C# class has a base class, then all those properties must also be included
This PR kind of solves this for interfaces. When a class has a base class that has also the TsExportInterfaceAttribute, and when the new flag is set this will make sure, that the interface is extended by the base class interface too.