### PR TITLE
fix(XmlDocs): properly handle assemblies without location

### DIFF
--- a/src/TypeGen/TypeGen.Core/Generator/Context/XmlDocs.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Context/XmlDocs.cs
@@ -28,7 +28,7 @@ internal class XmlDocs
 
         var xmlDocFilePath = Path.ChangeExtension(assemblyLocation, "xml");
         
-        var xmlDoc = _fileSystem.FileExists(xmlDocFilePath)
+        var xmlDoc = !String.IsNullOrEmpty(assemblyLocation) && _fileSystem.FileExists(xmlDocFilePath)
             ? _fileSystem.ReadFile(xmlDocFilePath)
             : null;
 


### PR DESCRIPTION
Assemblies loaded directly from a byte array will have a `Location` property of `""`. Currently, attempting to generate using these assemblies throws when adding `XmlDoc`, as it expects the `assemblyLocation` parameter to be non-empty.