### PR TITLE
Make PascalCaseToCamelCaseConverter match System.Text.Jsons naming policy

### DIFF
--- a/src/TypeGen/TypeGen.Core.Test/Converters/ConvertersTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/Converters/ConvertersTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using TypeGen.Core.Converters;
 using Xunit;
 
@@ -14,6 +15,7 @@ namespace TypeGen.Core.Test.Converters
         [InlineData("Some", "some")]
         [InlineData("ASomeName", "aSomeName")]
         [InlineData("ASomeAName", "aSomeAName")]
+        [InlineData("IMEI", "imei")]
         public void PascalCaseToCamelCaseConverter_Test(string input, string expectedResult)
         {
             //arrange
@@ -26,6 +28,27 @@ namespace TypeGen.Core.Test.Converters
             //assert
             Assert.Equal(expectedResult, actualResultMember);
             Assert.Equal(expectedResult, actualResultType);
+        }
+
+        [Theory]
+        [InlineData("SomeName")]
+        [InlineData("Some")]
+        [InlineData("ASomeName")]
+        [InlineData("ASomeAName")]
+        [InlineData("IMEI")]
+        public void PascalCaseToCamelCaseConverter_ShouldMatchSystemTextJsonPolicy(string input)
+        {
+            //arrange
+            var expected = JsonNamingPolicy.CamelCase.ConvertName(input);
+            var converter = new PascalCaseToCamelCaseConverter();
+
+            //act
+            string actualResultMember = converter.Convert(input, (MemberInfo)null);
+            string actualResultType = converter.Convert(input, (Type)null);
+
+            //assert
+            Assert.Equal(expected, actualResultMember);
+            Assert.Equal(expected, actualResultType);
         }
 
         [Theory]

--- a/src/TypeGen/TypeGen.Core.Test/Converters/ConvertersTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/Converters/ConvertersTest.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using TypeGen.Core.Converters;
 using Xunit;

--- a/src/TypeGen/TypeGen.Core/Converters/PascalCaseToCamelCaseConverter.cs
+++ b/src/TypeGen/TypeGen.Core/Converters/PascalCaseToCamelCaseConverter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Newtonsoft.Json.Serialization;
 using TypeGen.Core.Validation;
 
 namespace TypeGen.Core.Converters
@@ -11,6 +12,7 @@ namespace TypeGen.Core.Converters
     /// </summary>
     public class PascalCaseToCamelCaseConverter : IMemberNameConverter, ITypeNameConverter
     {
+        private static readonly CamelCasePropertyNamesContractResolver _resolver = new();
         public string Convert(string name, MemberInfo memberInfo)
         {
             Requires.NotNullOrEmpty(name, nameof(name));
@@ -25,36 +27,7 @@ namespace TypeGen.Core.Converters
 
         private static string ConvertTypeInvariant(string name)
         {
-            var chars = name.ToCharArray();
-            FixCasing(chars);
-            return new string(chars);
-        }
-
-        private static void FixCasing(IList<char> chars)
-        {
-            for (var i = 0; i < chars.Count; i++)
-            {
-                if (i == 1 && !char.IsUpper(chars[i]))
-                {
-                    break;
-                }
-
-                var hasNext = i + 1 < chars.Count;
-
-                // Stop when next char is already lowercase.
-                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
-                {
-                    // If the next char is a space, lowercase current char before exiting.
-                    if (chars[i + 1] == ' ')
-                    {
-                        chars[i] = char.ToLowerInvariant(chars[i]);
-                    }
-
-                    break;
-                }
-
-                chars[i] = char.ToLowerInvariant(chars[i]);
-            }
+            return _resolver.GetResolvedPropertyName(name);
         }
     }
 }

--- a/src/TypeGen/TypeGen.Core/Converters/PascalCaseToCamelCaseConverter.cs
+++ b/src/TypeGen/TypeGen.Core/Converters/PascalCaseToCamelCaseConverter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json.Serialization;
 using TypeGen.Core.Validation;

--- a/src/TypeGen/TypeGen.Core/Converters/PascalCaseToCamelCaseConverter.cs
+++ b/src/TypeGen/TypeGen.Core/Converters/PascalCaseToCamelCaseConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using TypeGen.Core.Validation;
@@ -24,8 +25,36 @@ namespace TypeGen.Core.Converters
 
         private static string ConvertTypeInvariant(string name)
         {
-            char firstChar = char.ToLowerInvariant(name[0]);
-            return firstChar + name.Remove(0, 1);
+            var chars = name.ToCharArray();
+            FixCasing(chars);
+            return new string(chars);
+        }
+
+        private static void FixCasing(IList<char> chars)
+        {
+            for (var i = 0; i < chars.Count; i++)
+            {
+                if (i == 1 && !char.IsUpper(chars[i]))
+                {
+                    break;
+                }
+
+                var hasNext = i + 1 < chars.Count;
+
+                // Stop when next char is already lowercase.
+                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+                {
+                    // If the next char is a space, lowercase current char before exiting.
+                    if (chars[i + 1] == ' ')
+                    {
+                        chars[i] = char.ToLowerInvariant(chars[i]);
+                    }
+
+                    break;
+                }
+
+                chars[i] = char.ToLowerInvariant(chars[i]);
+            }
         }
     }
 }


### PR DESCRIPTION
I've run into a bug where a property named `IMEI` is serialized as `iMEI` using TypeGen

However `System.Text.Json` and `Newtonsoft.Json` both serialize it as `imei`

So I've used Newtonsoft's contractResolver since it was available (System.Text.Json wasn't) 

Let me know if you want it made as a different converter instead. 

Edit:

I started out by recreating the logic - but eventually settled on using Newtonsoft as it was available