### PR TITLE
Import line break was not using the OS's newline

### DIFF
--- a/src/TypeGen/TypeGen.Core.Test/Generator/Services/TsContentGeneratorTest.cs
+++ b/src/TypeGen/TypeGen.Core.Test/Generator/Services/TsContentGeneratorTest.cs
@@ -107,7 +107,8 @@ namespace TypeGen.Core.Test.Generator.Services
                 "Child4 |  | ./child4/default/output/dir/child4;" +
                 "ChildEnum |  | ./child/dir/child-enum-dir/child-enum;" +
                 "CustomType |  | custom/directory/custom-type;" +
-                "OtherType | OT | other/directory/other-type;\r\n"
+                "OtherType | OT | other/directory/other-type;" +
+                Environment.NewLine
             },
 
             new object[] { typeof(GetImportsText_TestData.Parent), "./child/dir/", new TypeNameConverterCollection(new PascalCaseToKebabCaseConverter()), new TypeNameConverterCollection(),
@@ -121,17 +122,20 @@ namespace TypeGen.Core.Test.Generator.Services
                 "Child4 |  | ../../child4/default/output/dir/child4;" +
                 "ChildEnum |  | ./child-enum-dir/child-enum;" +
                 "CustomType |  | custom/directory/custom-type;" +
-                "OtherType | OT | other/directory/other-type;\r\n"
+                "OtherType | OT | other/directory/other-type;" +
+                Environment.NewLine
             },
             
             new object[] { typeof(GetImportsText_TestData.ParentCustomBase), null, new TypeNameConverterCollection(new PascalCaseToKebabCaseConverter()), new TypeNameConverterCollection(),
                 new TypeDependencyInfo[] {},
-                "Base |  | base/directory/base;\r\n"
+                "Base |  | base/directory/base;" +
+                Environment.NewLine
             },
             
             new object[] { typeof(GetImportsText_TestData.ParentCustomBaseAlias), null, new TypeNameConverterCollection(new PascalCaseToKebabCaseConverter()), new TypeNameConverterCollection(),
                 new TypeDependencyInfo[] {},
-                "Base | B | other/directory/base;\r\n"
+                "Base | B | other/directory/base;" +
+                Environment.NewLine
             },
         };
 

--- a/src/TypeGen/TypeGen.Core/Generator/Services/TsContentGenerator.cs
+++ b/src/TypeGen/TypeGen.Core/Generator/Services/TsContentGenerator.cs
@@ -79,7 +79,7 @@ namespace TypeGen.Core.Generator.Services
 
             if (!string.IsNullOrEmpty(result))
             {
-                result += "\r\n";
+                result += Environment.NewLine;
             }
 
             return result;


### PR DESCRIPTION
The new line following the import is fixed to `/r/n`. Elsewhere, it uses the OS newline. It should use the OS newline here too.