### PR TITLE
fix: compatibility with macOS .NET6+

### DIFF
--- a/src/TypeGen/TypeGen.Cli/Application.cs
+++ b/src/TypeGen/TypeGen.Cli/Application.cs
@@ -134,8 +134,17 @@ internal class Application : IApplication
         }
         catch (Exception e)
         {
-            _logger.Log($"{e.Message}{Environment.NewLine}{e.StackTrace}", LogLevel.Error);
+            LogExceptions(e);
             return ExitCode.Error;
+        }
+    }
+
+    private void LogExceptions(Exception e)
+    {
+        while (e != null)
+        {
+            _logger.Log($"{e.Message}{Environment.NewLine}{e.StackTrace}", LogLevel.Error);
+            e = e.InnerException;
         }
     }
 }

--- a/src/TypeGen/TypeGen.Cli/TypeResolution/AssemblyResolver.cs
+++ b/src/TypeGen/TypeGen.Cli/TypeResolution/AssemblyResolver.cs
@@ -147,7 +147,8 @@ namespace TypeGen.Cli.TypeResolution
             {
                 try
                 {
-                    Assembly assembly = Assembly.LoadFile(path);
+                    string fullPath = System.IO.Path.GetFullPath(path);
+                    Assembly assembly = Assembly.LoadFile(fullPath);
                     if (assembly.GetName().Version.ToString() == assemblyVersion)
                     {
                         _logger.Log($"Assembly '{assembly.FullName}' found in: {path}", LogLevel.Debug);

--- a/src/TypeGen/TypeGen.Core/Extensions/TypeExtensions.cs
+++ b/src/TypeGen/TypeGen.Core/Extensions/TypeExtensions.cs
@@ -104,9 +104,25 @@ namespace TypeGen.Core.Extensions
         public static bool IsNullable(this MemberInfo memberInfo)
         {
             Requires.NotNull(memberInfo, nameof(memberInfo));
-            
-            var contextualMember = memberInfo.ToContextualAccessor();
-            return contextualMember.Nullability == Nullability.Nullable;
+            #if NET6_0_OR_GREATER
+                var nullabilityInfoContext = new NullabilityInfoContext();
+                NullabilityInfo nullabilityInfo;
+                if (memberInfo is PropertyInfo propertyInfo)
+                {
+                    nullabilityInfo = nullabilityInfoContext.Create(propertyInfo);
+                }
+                else if (memberInfo is FieldInfo fieldInfo)
+                {
+                    nullabilityInfo = nullabilityInfoContext.Create(fieldInfo);
+                } else {
+                    throw new NotSupportedException("The member info must be a field or property.");
+                }
+                return nullabilityInfo.WriteState is NullabilityState.Nullable || 
+                    nullabilityInfo.ReadState is NullabilityState.Nullable;
+            #else
+                var contextualMember = memberInfo.ToContextualAccessor();
+                return contextualMember.Nullability == Nullability.Nullable;
+            #endif
         }
         
         /// <summary>


### PR DESCRIPTION
Several issues addressed to fix usage on internal project with mostly macOS environment:

1. `externalAssemblyPaths` should support entries with relative paths, hence resolution of such entries in AssemblyResolver
2. Print whole exception chain error
3.  Use [NullabilityInfoContext](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.nullabilityinfocontext) instead of [Namotion.Reflection](https://github.com/RicoSuter/Namotion.Reflection) on .NET6+

Without 3 generation doesn't work at all on macOS (for some reason windows is not affected by this issue). 
2 and 1 help with identifying and fixing this and future issues.

let me know if you need any other context